### PR TITLE
Fotoauswahl aus Galerie ermöglichen

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
           <strong>Fotos hinzufügen</strong><br>
           <small>Kamera oder Galerie · max. 9</small>
         </div>
-        <input type="file" id="photoInput" accept="image/*" multiple capture="environment" class="hidden">
+        <input type="file" id="photoInput" accept="image/*" multiple class="hidden">
         <div class="photo-grid" id="photoGrid"></div>
       </div>
 

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-2';
+const CACHE = 'techdoku-v2026-3';
 
 // Alles, was die App zum Laufen braucht – wird beim ersten Besuch gecacht
 const ASSETS = [


### PR DESCRIPTION
## Foto aus Galerie auswählbar

**Problem:** Auf vielen Handys öffnete der Foto-Button direkt die Kamera – die **Galerie** ließ sich nicht auswählen. Ursache war das Attribut `capture="environment"` am Datei-Input.

**Fix:** `capture` entfernt. Das Gerät zeigt jetzt wieder die gewohnte Auswahl **Kamera / Galerie / Dateien**. Mehrfachauswahl und Bildkompression bleiben unverändert.

Service-Worker-Cache-Version erhöht (`v2026-3`), damit alle Mitarbeiter die Änderung automatisch beim nächsten Laden erhalten.

https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S)_