### PR TITLE
📲 App installieren statt Webseiten-Gefühl: Install-Hilfe + Vollbild

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -57,9 +57,11 @@ body {
   background: var(--bg);
   color: var(--text);
   line-height: 1.45;
+  min-height: 100dvh; /* füllt den Bildschirm wie eine echte App */
   padding-bottom: calc(28px + var(--safe-bottom));
   transition: background .25s, color .25s;
   overflow-wrap: break-word;
+  overscroll-behavior-y: none; /* kein Webseiten-Gummiband / Ziehen-zum-Neuladen */
 }
 
 /* ===== Start-/Ladebildschirm (Splash) ===== */
@@ -540,6 +542,26 @@ input.ok-flash, textarea.ok-flash { border-color: var(--ok); animation: okPulse 
   border-top-color: #fff; border-radius: 50%; animation: spin 1s linear infinite;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
+
+/* ===== App-installieren-Karte ===== */
+.install-card {
+  position: relative; margin-top: 16px; padding: 16px;
+  border-radius: var(--radius); color: #fff;
+  background: linear-gradient(135deg, var(--accent-strong), #0e7490);
+  box-shadow: var(--shadow); animation: cardIn .4s ease both;
+}
+.install-close {
+  position: absolute; top: 8px; right: 8px; width: 30px; height: 30px;
+  border: none; border-radius: 50%; background: rgba(255,255,255,.18); color: #fff;
+  font-size: 14px; cursor: pointer; display: grid; place-items: center;
+}
+.install-top { display: flex; align-items: center; gap: 9px; font-size: 15.5px; }
+.install-ico { font-size: 22px; }
+.install-card p { font-size: 13px; opacity: .95; margin: 8px 0 12px; line-height: 1.5; }
+.install-card .btn-primary { background: #fff; color: var(--accent-strong); box-shadow: none; }
+.install-steps { margin: 10px 0 0; padding-left: 22px; font-size: 13.5px; line-height: 1.7; }
+.install-steps li { margin-bottom: 2px; }
+.install-steps b { font-weight: 700; }
 
 footer.app-foot { text-align: center; color: var(--text-muted); font-size: 12px; padding: 8px 16px 0; }
 

--- a/index.html
+++ b/index.html
@@ -215,6 +215,16 @@
       <div style="height:10px"></div>
       <button class="btn btn-ghost" id="btnNew" type="button">✨ Neues Formular / Leeren</button>
 
+      <!-- App installieren: macht aus dem Browser-Tab eine echte Vollbild-App -->
+      <div class="install-card hidden" id="installCard">
+        <button class="install-close" id="installClose" type="button" aria-label="Hinweis schließen">✕</button>
+        <div class="install-top"><span class="install-ico" aria-hidden="true">📲</span>
+          <strong>Als App installieren</strong></div>
+        <p id="installText">Auf dem Startbildschirm ablegen – dann öffnet sie im Vollbild, ohne Browserleiste, und fühlt sich an wie eine echte App.</p>
+        <button class="btn btn-primary" id="installBtn" type="button">📲 Jetzt installieren</button>
+        <ol class="install-steps hidden" id="installSteps"></ol>
+      </div>
+
       <footer class="app-foot">TechDoku · funktioniert auch offline · v2026</footer>
     </section>
   </main>

--- a/js/app.js
+++ b/js/app.js
@@ -28,6 +28,7 @@ function init() {
   initHistory();
   initProgress();
   initRipple();
+  initInstall();
   refreshSuggestions();
   setToday();
   const last = Settings.get().lastVerantwortlich;
@@ -44,6 +45,60 @@ function initSplash() {
   if (!el) return;
   const remove = () => { el.classList.add('gone'); setTimeout(() => el.remove(), 400); };
   setTimeout(remove, 1150);
+}
+
+/* ===================== App installieren ===================== */
+// Macht aus dem Browser-Tab eine echte Vollbild-App. Android/Chrome liefern
+// das beforeinstallprompt-Event; iOS/Safari kennt das nicht → Anleitung zeigen.
+function isStandalone() {
+  return matchMedia('(display-mode: standalone)').matches || navigator.standalone === true;
+}
+function isIOS() {
+  return /iphone|ipad|ipod/i.test(navigator.userAgent) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+}
+let deferredPrompt = null;
+
+function initInstall() {
+  const card = $('installCard');
+  // Schon installiert oder bewusst weggeklickt? Dann nichts zeigen.
+  if (isStandalone() || Settings.get().installDismissed) return;
+
+  $('installClose').onclick = () => { card.classList.add('hidden'); Settings.set({ installDismissed: true }); };
+
+  window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();
+    deferredPrompt = e;
+    $('installSteps').classList.add('hidden');
+    $('installBtn').classList.remove('hidden');
+    card.classList.remove('hidden');
+  });
+
+  $('installBtn').onclick = async () => {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    deferredPrompt = null;
+    if (outcome === 'accepted') card.classList.add('hidden');
+  };
+
+  window.addEventListener('appinstalled', () => {
+    card.classList.add('hidden');
+    Settings.set({ installDismissed: true });
+    toast('App installiert ✓ – ab jetzt im Vollbild');
+  });
+
+  // iOS: kein automatisches Prompt → Schritt-für-Schritt-Anleitung anzeigen
+  if (isIOS()) {
+    $('installBtn').classList.add('hidden');
+    $('installText').textContent = 'In Safari als App ablegen – dann öffnet sie im Vollbild ohne Browserleiste:';
+    const steps = $('installSteps');
+    steps.innerHTML = '<li>Unten auf <b>Teilen</b> tippen (das Symbol mit dem Pfeil ↑)</li>'
+      + '<li><b>„Zum Home-Bildschirm"</b> wählen</li>'
+      + '<li>Mit <b>„Hinzufügen"</b> bestätigen</li>';
+    steps.classList.remove('hidden');
+    card.classList.remove('hidden');
+  }
 }
 
 /* ===================== Service Worker (+ Update-Hinweis) ===================== */

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-10';
+const CACHE = 'techdoku-v2026-11';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier

--- a/tests/extras.spec.js
+++ b/tests/extras.spec.js
@@ -19,6 +19,49 @@ async function fillValid(page) {
   await expect(page.locator('#photoGrid .thumb')).toHaveCount(1);
 }
 
+test('Install-Banner: versteckt ohne Prompt, erscheint bei beforeinstallprompt', async ({ page }) => {
+  await page.goto('/');
+  // Ohne Installierbarkeit (Desktop-Chromium, kein iOS) bleibt es versteckt
+  await expect(page.locator('#installCard')).toBeHidden();
+
+  // Android/Chrome-Verhalten simulieren
+  const choice = await page.evaluate(() => {
+    let prompted = false;
+    const e = new Event('beforeinstallprompt');
+    e.prompt = () => { prompted = true; };
+    e.userChoice = Promise.resolve({ outcome: 'accepted' });
+    window.dispatchEvent(e);
+    window.__wasPrompted = () => prompted;
+    return document.getElementById('installCard').classList.contains('hidden');
+  });
+  expect(choice).toBe(false); // Banner ist jetzt sichtbar
+  await expect(page.locator('#installCard')).toBeVisible();
+
+  // Klick löst das native Prompt aus
+  await page.click('#installBtn');
+  expect(await page.evaluate(() => window.__wasPrompted())).toBe(true);
+});
+
+test('Install-Banner: Schließen merkt sich die Entscheidung', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => {
+    const e = new Event('beforeinstallprompt');
+    e.prompt = () => {}; e.userChoice = Promise.resolve({ outcome: 'dismissed' });
+    window.dispatchEvent(e);
+  });
+  await expect(page.locator('#installCard')).toBeVisible();
+  await page.click('#installClose');
+  await expect(page.locator('#installCard')).toBeHidden();
+  // Nach Reload bleibt es weg (Entscheidung gemerkt)
+  await page.reload();
+  await page.evaluate(() => {
+    const e = new Event('beforeinstallprompt');
+    e.prompt = () => {}; e.userChoice = Promise.resolve({ outcome: 'dismissed' });
+    window.dispatchEvent(e);
+  });
+  await expect(page.locator('#installCard')).toBeHidden();
+});
+
 test('gültig befülltes Pflichtfeld bekommt einen grünen Impuls', async ({ page }) => {
   await page.goto('/');
   await page.fill('#kunde', 'Andritz Hydro GmbH');


### PR DESCRIPTION
## 📲 Echtes App-Gefühl statt „Webseite" – Installier-Hilfe + Vollbild

### Warum es sich wie eine Webseite anfühlt
Die App ist technisch schon eine vollwertige PWA (`display: standalone`) — **aber nur, wenn sie auf dem Startbildschirm installiert ist**. Solange sie im Browser-Tab läuft, zeigt das Handy die Adressleiste und das typische „Ziehen zum Aktualisieren" → es fühlt sich wie eine Webseite an. Die meisten wissen nicht, dass/wie man sie installiert.

### Lösung
- **„Als App installieren"-Karte** unten im Formular:
  - **Android/Chrome:** Button löst den **nativen Installationsdialog** aus (`beforeinstallprompt`)
  - **iOS/Safari:** klare **3-Schritte-Anleitung** (Teilen → „Zum Home-Bildschirm" → Hinzufügen), da iOS kein Auto-Prompt kennt
  - **Versteckt sich automatisch**, wenn die App bereits installiert läuft oder der Hinweis weggeklickt wurde (Entscheidung wird gemerkt — kein Nerven)
  - Nach erfolgreicher Installation: Banner weg + kurze Bestätigung
- **`overscroll-behavior-y: none`** → kein Webseiten-Gummiband / Ziehen-zum-Neuladen mehr
- **`min-height: 100dvh`** → die App füllt den Bildschirm sauber aus

Nach dem Installieren öffnet die App **im Vollbild ohne Browserleiste** — dann fühlt sie sich an wie eine echte App. 🎉

### Qualität
- 2 neue Tests (Banner erscheint bei Prompt, Klick löst Installation aus, Schließen wird gemerkt)
- **45 Tests gesamt, alle grün**, beide Varianten visuell verifiziert (Android + iOS)
- Offline-fähig, SW-Cache-Version erhöht

https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S)_