### PR TITLE
🏠 Dritte Auftragsart „Privat" für private Dokumentation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -400,6 +400,7 @@ input.ok-flash, textarea.ok-flash { border-color: var(--ok); animation: okPulse 
 .input-with-btn textarea { flex: 1; }
 
 .seg { position: relative; display: grid; grid-template-columns: 1fr 1fr; gap: 8px; border-radius: var(--radius-sm); }
+.seg.seg-3 { grid-template-columns: 1fr 1fr 1fr; }
 .seg input { position: absolute; opacity: 0; pointer-events: none; }
 /* Gleitender Auswahl-Hintergrund (Pille), der zwischen den Optionen wandert */
 .seg::before {
@@ -410,14 +411,18 @@ input.ok-flash, textarea.ok-flash { border-color: var(--ok); animation: okPulse 
   opacity: 0; pointer-events: none;
   transition: transform .28s cubic-bezier(.2, .8, .2, 1), opacity .2s;
 }
+.seg.seg-3::before { width: calc((100% - 16px) / 3); }
 .seg:has(#typRekl:checked)::before { opacity: 1; transform: translateX(0); }
 .seg:has(#typFert:checked)::before { opacity: 1; transform: translateX(calc(100% + 8px)); }
+.seg:has(#typPriv:checked)::before { opacity: 1; transform: translateX(calc(200% + 16px)); }
 .seg label {
   position: relative; z-index: 1;
-  margin: 0; text-align: center; padding: 14px 8px; cursor: pointer;
+  margin: 0; text-align: center; padding: 14px 6px; cursor: pointer;
   border: 1.5px solid var(--border); border-radius: var(--radius-sm);
-  background: var(--surface-2); font-weight: 600; transition: color .2s, border-color .2s, background .2s;
+  background: var(--surface-2); font-weight: 600; font-size: 14px;
+  transition: color .2s, border-color .2s, background .2s;
 }
+.seg.seg-3 label { font-size: 11.5px; padding: 13px 2px; letter-spacing: -.01em; }
 /* Aktive Option: Hintergrund kommt von der Pille → Label transparent */
 .seg input:checked + label {
   border-color: transparent; background: transparent; color: var(--accent-strong); font-weight: 700;

--- a/index.html
+++ b/index.html
@@ -136,11 +136,13 @@
         <div class="card-title"><span class="num">1</span> Auftrag</div>
         <div class="field" data-for="auftragstyp">
           <label id="lblTyp">Auftragstyp <span class="req">*</span></label>
-          <div class="seg" role="radiogroup" aria-labelledby="lblTyp">
+          <div class="seg seg-3" role="radiogroup" aria-labelledby="lblTyp">
             <input type="radio" name="auftragstyp" id="typRekl" value="Reklamation">
             <label for="typRekl">⚠️ Reklamation</label>
             <input type="radio" name="auftragstyp" id="typFert" value="Fertigungsauftrag">
-            <label for="typFert">🏭 Fertigungsauftrag</label>
+            <label for="typFert">🏭 Fertigung</label>
+            <input type="radio" name="auftragstyp" id="typPriv" value="Privat">
+            <label for="typPriv">🏠 Privat</label>
           </div>
           <div class="field-msg">Bitte auswählen.</div>
         </div>

--- a/js/app.js
+++ b/js/app.js
@@ -8,8 +8,13 @@ import { zoneLabel } from './zones.js';
 const $ = (id) => document.getElementById(id);
 const MAX_IMAGES = 9;
 const SUGGEST_FIELDS = ['kunde', 'maschine', 'verantwortlich', 'teilebenennung'];
-// Pflichttextfelder (datum hat Default); stueckzahl & auftragstyp werden gesondert geprüft
+// Pflichttextfelder je Auftragstyp (datum hat Default; stueckzahl & auftragstyp
+// werden gesondert geprüft). "Privat" braucht nur das Nötigste.
 const REQUIRED = ['kunde', 'maschine', 'abnr', 'zeichnungsnummer', 'index', 'verantwortlich', 'datum', 'teilebenennung', 'bemerkung'];
+const REQUIRED_PRIVAT = ['teilebenennung', 'datum', 'bemerkung'];
+// Felder, die bei "Privat" ausgeblendet werden (ergeben privat keinen Sinn)
+const PRIVAT_HIDE = ['kunde', 'maschine', 'abnr', 'position', 'zeichnungsnummer', 'index', 'stueckzahl'];
+function requiredFor(typ) { return typ === 'Privat' ? REQUIRED_PRIVAT : REQUIRED; }
 const DRAFT_FIELDS = ['auftragstyp', 'kunde', 'maschine', 'abnr', 'position', 'zeichnungsnummer', 'index', 'verantwortlich', 'datum', 'teilebenennung', 'stueckzahl', 'version', 'spanndruck', 'bemerkung'];
 
 let images = []; // [{ id, src, name, caption }]
@@ -159,6 +164,16 @@ function initType() {
 function updateTypeFields(val) {
   $('versionField').classList.toggle('hidden', val !== 'Reklamation');
   $('spanndruckField').classList.toggle('hidden', val !== 'Fertigungsauftrag');
+
+  // Bei "Privat": fertigungsspezifische Felder ausblenden
+  const priv = val === 'Privat';
+  PRIVAT_HIDE.forEach((id) => $(id).closest('.field').classList.toggle('hidden', priv));
+
+  // Bezeichnungs-Feld passend benennen + Verantwortlich privat optional
+  $('teilebenennung').closest('.field').querySelector('label').innerHTML =
+    (priv ? 'Bezeichnung' : 'Benennung der Teile') + ' <span class="req">*</span>';
+  const veraReq = $('verantwortlich').closest('.field').querySelector('.req');
+  if (veraReq) veraReq.style.display = priv ? 'none' : '';
 }
 function currentType() { return document.querySelector('input[name=auftragstyp]:checked')?.value || ''; }
 
@@ -454,11 +469,12 @@ function validate() {
   let firstBad = null;
   const flag = (el) => { if (!firstBad) firstBad = el; };
 
+  const priv = doc.auftragstyp === 'Privat';
   if (!doc.auftragstyp) { setTypeError(true); flag(document.querySelector('[data-for=auftragstyp]')); }
-  for (const f of REQUIRED) {
+  for (const f of requiredFor(doc.auftragstyp)) {
     if (!String(doc[f] || '').trim()) { setErr(f, true); flag($(f)); }
   }
-  if (!(Number(doc.stueckzahl) > 0)) { setErr('stueckzahl', true, 'Muss größer als 0 sein.'); flag($('stueckzahl')); }
+  if (!priv && !(Number(doc.stueckzahl) > 0)) { setErr('stueckzahl', true, 'Muss größer als 0 sein.'); flag($('stueckzahl')); }
   if (doc.auftragstyp === 'Reklamation' && !doc.version.trim()) { setErr('version', true); flag($('version')); }
   if (doc.auftragstyp === 'Fertigungsauftrag' && !doc.spanndruck.trim()) { setErr('spanndruck', true); flag($('spanndruck')); }
   if (!images.length) { $('photoMsg').style.display = 'block'; flag($('photoArea')); }

--- a/js/pdf.js
+++ b/js/pdf.js
@@ -35,6 +35,7 @@ function nowStr() {
 }
 
 function docRef(doc) {
+  if (doc.auftragstyp === 'Privat') return fmtDate(doc.datum);
   const c = (s) => String(s || '–');
   return `AB ${c(doc.abnr)} · Z ${c(doc.zeichnungsnummer)} · Index ${c(doc.index)}`;
 }
@@ -42,6 +43,7 @@ function docRef(doc) {
 export function buildFilename(doc) {
   const part = (s) => String(s || '').trim().replace(/[\\/:*?"<>|]+/g, '_').replace(/\s+/g, '_').slice(0, 40);
   const date = doc.datum || new Date().toISOString().slice(0, 10);
+  if (doc.auftragstyp === 'Privat') return `Privat_${part(doc.teilebenennung) || 'Doku'}_${date}.pdf`;
   return `AB${part(doc.abnr)}_Z${part(doc.zeichnungsnummer)}_I${part(doc.index)}_${date}.pdf`;
 }
 
@@ -124,10 +126,16 @@ function metaTable(pdf, doc, startY) {
   if (doc.position) pairs.splice(3, 0, ['Position', doc.position]);
   if (doc.auftragstyp === 'Reklamation' && doc.version) pairs.push(['Version', doc.version]);
   if (doc.auftragstyp === 'Fertigungsauftrag' && doc.spanndruck) pairs.push(['Spanndruck', doc.spanndruck]);
+  // Privat: passendes Label, fertigungsfremde Felder fallen unten ohnehin weg
+  if (doc.auftragstyp === 'Privat') {
+    const t = pairs.find((p) => p[0] === 'Benennung der Teile'); if (t) t[0] = 'Bezeichnung';
+  }
+  // Leere Felder nicht anzeigen (sauberes Layout, v.a. bei Privat)
+  const shown = pairs.filter(([, v]) => String(v || '').trim());
 
   const colW = CW / 2;
   const innerW = colW - 5;
-  const rowsN = Math.ceil(pairs.length / 2);
+  const rowsN = Math.ceil(shown.length / 2);
   let y = startY;
 
   pdf.setDrawColor(...C_LINE);
@@ -139,8 +147,8 @@ function metaTable(pdf, doc, startY) {
     let lineCount = 1;
     for (let c = 0; c < 2; c++) {
       const idx = r * 2 + c;
-      if (idx >= pairs.length) { cells.push(null); continue; }
-      const [label, value] = pairs[idx];
+      if (idx >= shown.length) { cells.push(null); continue; }
+      const [label, value] = shown[idx];
       pdf.setFont('helvetica', 'normal'); pdf.setFontSize(9.5);
       const vLines = pdf.splitTextToSize(String(value || '–'), innerW).slice(0, 2);
       lineCount = Math.max(lineCount, vLines.length);

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-13';
+const CACHE = 'techdoku-v2026-14';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -89,6 +89,28 @@ test('Theme-Umschalter wechselt und bleibt nach Reload erhalten', async ({ page 
   await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
 });
 
+test('Privat: blendet Fertigungsfelder aus und erstellt PDF ohne Pflicht-AB-Nr.', async ({ page }) => {
+  await page.goto('/');
+  await page.click('label[for=typPriv]');
+  // Fertigungsspezifische Felder verschwinden
+  await expect(page.locator('#abnr').locator('xpath=ancestor::div[contains(@class,"field")][1]')).toBeHidden();
+  await expect(page.locator('#maschine').locator('xpath=ancestor::div[contains(@class,"field")][1]')).toBeHidden();
+  await expect(page.locator('#stueckzahl').locator('xpath=ancestor::div[contains(@class,"field")][1]')).toBeHidden();
+  // Bezeichnung wird umbenannt
+  await expect(page.locator('label[for=teilebenennung]')).toContainText('Bezeichnung');
+
+  // Nur das Nötigste ausfüllen
+  await page.fill('#teilebenennung', 'Gartenzaun Schaden');
+  await page.fill('#bemerkung', 'Privat dokumentiert.');
+  await page.setInputFiles('#galleryInput', { name: 'p.png', mimeType: 'image/png', buffer: PNG });
+  await expect(page.locator('#photoGrid .thumb')).toHaveCount(1);
+
+  const dl = page.waitForEvent('download');
+  await page.click('#btnPdf');
+  const download = await dl;
+  expect(download.suggestedFilename()).toContain('Privat_Gartenzaun_Schaden_');
+});
+
 test('Auftragstyp blendet das passende Zusatzfeld ein', async ({ page }) => {
   await page.goto('/');
   await page.click('label[for=typRekl]');


### PR DESCRIPTION
## 🏠 Dritte Auftragsart „Privat"

Wie gewünscht: neben **Reklamation** und **Fertigung** gibt es jetzt **Privat** – für alles, was privat anfällt und trotzdem sauber mit Fotos & Notizen dokumentiert werden soll.

### Verhalten bei „Privat"
- Der Auftragstyp-Schalter ist jetzt **dreispaltig**, die gleitende Markierung wandert auch auf die dritte Option
- Fertigungsspezifische Felder werden **ausgeblendet** (Kunde, Maschine, AB-Nr., Position, Zeichnungsnr., Index, Stückzahl) – die ergeben privat keinen Sinn
- **Pflicht nur noch:** Bezeichnung, Datum, Bemerkung + mindestens 1 Foto (Verantwortlich optional)
- Das Feld „Benennung der Teile" heißt im Privat-Modus **„Bezeichnung"**

### PDF
- **Leere Felder werden weggelassen** → sauberes Layout (gilt auch allgemein)
- Kopf-Referenz zeigt bei Privat das **Datum** statt AB/Zeichnungsnr.
- Dateiname: `Privat_<Bezeichnung>_<Datum>.pdf`
- Das Typ-Badge oben im PDF zeigt „Privat"

### Qualität
- Neuer Test: Privat blendet Fertigungsfelder aus und erstellt ein PDF **ohne** Pflicht-AB-Nr.
- Bestehende Reklamations-/Fertigungs-Tests unverändert grün
- **56 Tests gesamt, alle grün**, visuell verifiziert
- Offline-fähig, SW-Cache-Version erhöht

https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S)_