### PR TITLE
📁 Archiv: fertige Dokumentationen inkl. Fotos speichern (IndexedDB)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -339,14 +339,16 @@ main { max-width: 760px; margin: 0 auto; padding: 16px; }
 .hist-main:active { transform: scale(.985); }
 .hist-main:hover { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
 .hist-ico { font-size: 20px; flex: 0 0 auto; }
+.hist-thumb { width: 38px; height: 38px; flex: 0 0 auto; border-radius: 8px; object-fit: cover; border: 1px solid var(--border); }
 .hist-txt { flex: 1; min-width: 0; }
 .hist-txt strong { display: block; font-size: 14.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .hist-txt small { display: block; color: var(--text-muted); font-size: 12px; margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .hist-go { color: var(--accent); font-size: 17px; flex: 0 0 auto; }
-.hist-del {
+.hist-pdf, .hist-del {
   flex: 0 0 auto; width: 42px; border: 1.5px solid var(--border); border-radius: var(--radius-sm);
   background: var(--surface-2); cursor: pointer; font-size: 15px; color: var(--text-muted);
 }
+.hist-pdf:hover { color: var(--accent); border-color: var(--accent); }
 .hist-del:hover { color: var(--danger); border-color: var(--danger); }
 .card-title {
   display: flex; align-items: center; gap: 9px;

--- a/index.html
+++ b/index.html
@@ -122,13 +122,13 @@
         </button>
       </div>
 
-      <!-- Verlauf: frühere Dokus als Vorlage wiederverwenden -->
+      <!-- Archiv: gespeicherte Dokus (inkl. Fotos) wieder öffnen / teilen -->
       <div class="card history-card hidden" id="historyCard">
         <div class="card-title">
-          <span class="num">↻</span> Letzte Dokumentationen
+          <span class="num">📁</span> Archiv
           <button class="hist-toggle" id="histToggle" type="button" aria-expanded="false">Alle anzeigen</button>
         </div>
-        <p class="hist-sub">Antippen, um die Daten als Vorlage zu übernehmen (Fotos kommen neu dazu).</p>
+        <p class="hist-sub">Antippen zum Laden (mit Fotos) · 📄 erneut als PDF teilen · 🗑 löschen.</p>
         <div id="historyList"></div>
       </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,5 @@
-import { Settings, Suggest, Draft, History, Zones } from './store.js';
+import { Settings, Suggest, Draft, Zones } from './store.js';
+import { Archive } from './archive.js';
 import { createPDF, buildFilename } from './pdf.js';
 import { annotate } from './annotate.js';
 import { scanArbeitskarte } from './scan.js';
@@ -32,7 +33,7 @@ function init() {
   initLightbox();
   initLiveValidation();
   initDraftAutosave();
-  initHistory();
+  initArchive();
   initProgress();
   initRipple();
   initInstall();
@@ -496,7 +497,7 @@ function initActions() {
     try {
       const pdf = await createPDF(doc);
       pdf.save(buildFilename(doc));
-      finalize(doc);
+      await finalize(doc);
       celebrate('PDF erstellt!');
     } finally { hideLoading(); }
   });
@@ -510,11 +511,11 @@ function initActions() {
     try {
       if (navigator.canShare && navigator.canShare({ files: [file] })) {
         await navigator.share({ title: 'Technische Dokumentation S. Fritz', text: 'Technische Dokumentation (PDF)', files: [file] });
-        finalize(doc);
+        await finalize(doc);
         celebrate('PDF geteilt!');
       } else {
         pdf.save(buildFilename(doc));
-        finalize(doc);
+        await finalize(doc);
         toast('Teilen nicht unterstützt – PDF gespeichert');
       }
     } catch (e) { if (e?.name !== 'AbortError') toast('Teilen abgebrochen'); }
@@ -545,14 +546,17 @@ function withDoc(btnId, fn) {
   };
 }
 
-// Nach erfolgreichem Erstellen/Teilen: Vorschläge & Verlauf merken, Entwurf löschen
-function finalize(doc) {
+// Nach erfolgreichem Erstellen/Teilen: Vorschläge merken, ins Archiv legen,
+// Entwurf löschen. Das Archiv speichert die komplette Doku inkl. Fotos.
+async function finalize(doc) {
   SUGGEST_FIELDS.forEach((f) => Suggest.remember(f, doc[f]));
   if (doc.verantwortlich) Settings.set({ lastVerantwortlich: doc.verantwortlich.trim() });
   refreshSuggestions();
-  const { images: _imgs, ...fields } = doc; // Verlauf ohne Fotos (klein halten)
-  History.add(fields);
-  renderHistory();
+  const { images, ...fields } = doc;
+  try {
+    await Archive.add({ id: 'a' + Date.now(), createdAt: Date.now(), fields, images: images || [] });
+    await renderArchive();
+  } catch { /* Archiv optional – Fehler nicht blockierend */ }
   Draft.clear();
   hideDraftBanner();
 }
@@ -592,21 +596,23 @@ function hideDraftBanner() { $('draftBanner').classList.add('hidden'); }
 
 /* ===================== Verlauf (Vorlagen) ===================== */
 const HIST_PREVIEW = 3; // eingeklappt sichtbare Einträge
+const TYPE_ICON = { Reklamation: '⚠️', Fertigungsauftrag: '🏭', Privat: '🏠' };
 
-function initHistory() {
+function initArchive() {
   $('histToggle').onclick = () => {
     const btn = $('histToggle');
     const open = btn.getAttribute('aria-expanded') === 'true';
     btn.setAttribute('aria-expanded', String(!open));
     btn.textContent = open ? 'Alle anzeigen' : 'Weniger';
-    renderHistory();
+    renderArchive();
   };
-  renderHistory();
+  renderArchive();
 }
 
-function renderHistory() {
+async function renderArchive() {
+  let list = [];
+  try { list = await Archive.list(); } catch { list = []; }
   const card = $('historyCard');
-  const list = History.list();
   card.classList.toggle('hidden', list.length === 0);
   if (!list.length) return;
 
@@ -620,41 +626,71 @@ function renderHistory() {
     const f = e.fields || {};
     const d = new Date(e.createdAt);
     const when = `${String(d.getDate()).padStart(2, '0')}.${String(d.getMonth() + 1).padStart(2, '0')}.${d.getFullYear()}`;
+    const thumb = (e.images && e.images[0] && e.images[0].src) || '';
+    const nPhotos = (e.images || []).length;
     const row = document.createElement('div');
     row.className = 'hist-row';
     row.innerHTML = `
       <button class="hist-main" type="button">
-        <span class="hist-ico">${f.auftragstyp === 'Reklamation' ? '⚠️' : '🏭'}</span>
+        ${thumb ? `<img class="hist-thumb" src="${thumb}" alt="">` : `<span class="hist-ico">${TYPE_ICON[f.auftragstyp] || '📄'}</span>`}
         <span class="hist-txt">
           <strong>${esc(f.teilebenennung || f.kunde || 'Dokumentation')}</strong>
-          <small>${esc([f.kunde, f.abnr, when].filter(Boolean).join(' · '))}</small>
+          <small>${esc([f.kunde, f.abnr, when].filter(Boolean).join(' · '))}${nPhotos ? ` · ${nPhotos} 📷` : ''}</small>
         </span>
         <span class="hist-go" aria-hidden="true">↪</span>
       </button>
+      <button class="hist-pdf" type="button" aria-label="Als PDF teilen" title="Als PDF teilen">📄</button>
       <button class="hist-del" type="button" aria-label="Eintrag löschen" title="Löschen">🗑</button>`;
-    row.querySelector('.hist-main').onclick = () => applyHistory(e);
-    row.querySelector('.hist-del').onclick = () => { History.remove(e.id); renderHistory(); };
+    row.querySelector('.hist-main').onclick = () => loadArchiveEntry(e);
+    row.querySelector('.hist-pdf').onclick = () => sharePdfFromEntry(e);
+    row.querySelector('.hist-del').onclick = async () => {
+      if (!confirm('Diesen Archiv-Eintrag löschen?')) return;
+      await Archive.remove(e.id); renderArchive();
+    };
     box.appendChild(row);
   });
 }
 
-function applyHistory(entry) {
+// Vollständige Doku (inkl. Fotos) zurück ins Formular laden
+function loadArchiveEntry(entry) {
   const dirty = images.length || $('kunde').value.trim() || $('bemerkung').value.trim();
-  if (dirty && !confirm('Aktuelle Eingaben mit dieser Vorlage überschreiben?')) return;
+  if (dirty && !confirm('Aktuelle Eingaben mit dieser gespeicherten Doku überschreiben?')) return;
   const f = entry.fields || {};
   $('typRekl').checked = f.auftragstyp === 'Reklamation';
   $('typFert').checked = f.auftragstyp === 'Fertigungsauftrag';
+  $('typPriv').checked = f.auftragstyp === 'Privat';
   updateTypeFields(f.auftragstyp || '');
-  DRAFT_FIELDS.filter((k) => k !== 'auftragstyp' && k !== 'datum').forEach((k) => { $(k).value = f[k] || ''; });
-  setTodayForce();
+  DRAFT_FIELDS.filter((k) => k !== 'auftragstyp').forEach((k) => { $(k).value = f[k] || ''; });
+  setToday();
+  images = (entry.images || []).map((im, i) => ({
+    id: 'img_' + Date.now() + '_' + i, src: im.src, name: im.name || ('Bild' + (i + 1)), caption: im.caption || '',
+  }));
+  renderPhotos();
   clearAllErrors();
   saveDraft();
   updateProgress();
   vibrate(15);
-  toast('Vorlage übernommen – Fotos hinzufügen 📷');
+  toast('Doku geladen – bearbeiten oder neu teilen');
   $('kunde').scrollIntoView({ behavior: 'smooth', block: 'center' });
 }
-function setTodayForce() { $('datum').value = new Date().toISOString().slice(0, 10); }
+
+// Direkt aus dem Archiv erneut als PDF teilen/speichern
+async function sharePdfFromEntry(entry) {
+  const doc = { ...(entry.fields || {}), images: entry.images || [] };
+  showLoading('PDF wird vorbereitet…');
+  let pdf;
+  try { pdf = await createPDF(doc); } catch (e) { hideLoading(); toast('Fehler bei der PDF-Erstellung'); return; }
+  const file = new File([pdf.output('blob')], buildFilename(doc), { type: 'application/pdf' });
+  hideLoading();
+  try {
+    if (navigator.canShare && navigator.canShare({ files: [file] })) {
+      await navigator.share({ title: 'Technische Dokumentation S. Fritz', text: 'Technische Dokumentation (PDF)', files: [file] });
+    } else {
+      pdf.save(buildFilename(doc));
+      toast('PDF gespeichert');
+    }
+  } catch (e) { if (e?.name !== 'AbortError') toast('Teilen abgebrochen'); }
+}
 
 /* ===================== Fortschrittsanzeige ===================== */
 // Zählt Auftragstyp, Pflichtfelder (inkl. typabhängiger) und Fotos.

--- a/js/archive.js
+++ b/js/archive.js
@@ -1,0 +1,62 @@
+// Archiv abgeschlossener Dokumentationen – inkl. Fotos. Nutzt IndexedDB, da
+// Fotos (Daten-URLs) für localStorage zu groß wären. Rein lokal, kein Netz.
+
+const DB = 'techdoku-db';
+const STORE = 'docs';
+const MAX = 40; // älteste darüber hinaus werden beim Speichern entfernt
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const rq = indexedDB.open(DB, 1);
+    rq.onupgradeneeded = () => {
+      const db = rq.result;
+      if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE, { keyPath: 'id' });
+    };
+    rq.onsuccess = () => resolve(rq.result);
+    rq.onerror = () => reject(rq.error);
+  });
+}
+
+function withStore(mode, fn) {
+  return openDB().then((db) => new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, mode);
+    const store = tx.objectStore(STORE);
+    const out = fn(store);
+    tx.oncomplete = () => resolve(out && out._result !== undefined ? out._result : out);
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  }));
+}
+
+export const Archive = {
+  async list() {
+    return withStore('readonly', (store) => {
+      const holder = {};
+      store.getAll().onsuccess = (e) => { holder._result = (e.target.result || []).sort((a, b) => b.createdAt - a.createdAt); };
+      return holder;
+    });
+  },
+  async get(id) {
+    return withStore('readonly', (store) => {
+      const holder = {};
+      store.get(id).onsuccess = (e) => { holder._result = e.target.result; };
+      return holder;
+    });
+  },
+  async add(rec) {
+    await withStore('readwrite', (store) => { store.put(rec); });
+    // Auf MAX begrenzen (älteste löschen)
+    const all = await this.list();
+    if (all.length > MAX) {
+      const drop = all.slice(MAX);
+      await withStore('readwrite', (store) => { drop.forEach((d) => store.delete(d.id)); });
+    }
+    return rec;
+  },
+  async remove(id) {
+    return withStore('readwrite', (store) => { store.delete(id); });
+  },
+  async clear() {
+    return withStore('readwrite', (store) => { store.clear(); });
+  },
+};

--- a/js/store.js
+++ b/js/store.js
@@ -4,7 +4,6 @@
 const KEY_SETTINGS = 'techdoku_settings';
 const KEY_SUGGEST = 'techdoku_suggest';
 const KEY_DRAFT = 'techdoku_draft';
-const KEY_HISTORY = 'techdoku_history';
 const KEY_ZONES = 'techdoku_zones';
 
 function read(key) { try { return JSON.parse(localStorage.getItem(key)); } catch { return null; } }
@@ -42,21 +41,8 @@ export const Draft = {
   clear() { try { localStorage.removeItem(KEY_DRAFT); } catch {} }
 };
 
-// Verlauf erstellter Dokus – dient als Vorlage für Wiederholteile.
-// Pro Eintrag nur die Textfelder + Zeitstempel (keine Bilder).
-export const History = {
-  list() { return read(KEY_HISTORY) || []; },
-  add(fields) {
-    const entry = { id: 'h' + Date.now(), fields, createdAt: Date.now() };
-    const list = [entry, ...this.list()].slice(0, 25);
-    write(KEY_HISTORY, list);
-    return entry;
-  },
-  remove(id) {
-    write(KEY_HISTORY, this.list().filter((e) => e.id !== id));
-  },
-  clear() { try { localStorage.removeItem(KEY_HISTORY); } catch {} }
-};
+// Hinweis: Das frühere localStorage-"History" (nur Text) wurde durch das
+// vollwertige Archiv (js/archive.js, IndexedDB inkl. Fotos) ersetzt.
 
 // Scan-Vorlage: vom Nutzer auf einem Karten-Foto eingezeichnete Zonen.
 // Pro Zone: { field, x, y, w, h } – x/y/w/h als Anteil 0..1 des Bildes (so

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-14';
+const CACHE = 'techdoku-v2026-15';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier
@@ -17,6 +17,7 @@ const ASSETS = [
   './js/cardparse.js',
   './js/zones.js',
   './js/zonecal.js',
+  './js/archive.js',
   './vendor/jspdf.umd.min.js',
   './manifest.json',
   './icon-192.png',

--- a/tests/extras.spec.js
+++ b/tests/extras.spec.js
@@ -80,7 +80,7 @@ test('Fortschrittsring steigt beim Ausfüllen und erreicht 100 %', async ({ page
   await expect(page.locator('#progressRing')).toHaveClass(/done/);
 });
 
-test('Verlauf: nach PDF-Erstellung erscheint die Doku als Vorlage', async ({ page }) => {
+test('Archiv: nach PDF-Erstellung erscheint die Doku (überlebt Reload)', async ({ page }) => {
   await page.goto('/');
   await fillValid(page);
   const dl = page.waitForEvent('download');
@@ -91,16 +91,16 @@ test('Verlauf: nach PDF-Erstellung erscheint die Doku als Vorlage', async ({ pag
   await expect(page.locator('#successOverlay')).toBeVisible();
   await expect(page.locator('#successOverlay')).toBeHidden({ timeout: 5000 });
 
-  // Verlauf zeigt den Eintrag
+  // Archiv zeigt den Eintrag
   await expect(page.locator('#historyCard')).toBeVisible();
   await expect(page.locator('.hist-txt strong').first()).toHaveText('Sensor Kontakt');
 
-  // Verlauf überlebt einen Reload
+  // Archiv überlebt einen Reload (IndexedDB)
   await page.reload();
   await expect(page.locator('#historyCard')).toBeVisible();
 });
 
-test('Verlauf: Antippen übernimmt die Daten als Vorlage (ohne Fotos)', async ({ page }) => {
+test('Archiv: Antippen lädt die komplette Doku inkl. Fotos', async ({ page }) => {
   await page.goto('/');
   await fillValid(page);
   const dl = page.waitForEvent('download');
@@ -108,20 +108,21 @@ test('Verlauf: Antippen übernimmt die Daten als Vorlage (ohne Fotos)', async ({
   await dl;
   await expect(page.locator('#successOverlay')).toBeHidden({ timeout: 5000 });
 
-  // Formular leeren, dann Vorlage anwenden
+  // Formular leeren, dann aus dem Archiv laden
   page.on('dialog', (d) => d.accept());
   await page.click('#btnNew');
   await expect(page.locator('#kunde')).toHaveValue('');
+  await expect(page.locator('#photoGrid .thumb')).toHaveCount(0);
 
   await page.click('.hist-main');
   await expect(page.locator('#kunde')).toHaveValue('Andritz Hydro GmbH');
   await expect(page.locator('#zeichnungsnummer')).toHaveValue('704097971');
   await expect(page.locator('#typRekl')).toBeChecked();
-  // Fotos kommen NICHT aus der Vorlage
-  await expect(page.locator('#photoGrid .thumb')).toHaveCount(0);
+  // Fotos werden mitgeladen
+  await expect(page.locator('#photoGrid .thumb')).toHaveCount(1);
 });
 
-test('Verlauf: Eintrag löschen entfernt ihn dauerhaft', async ({ page }) => {
+test('Archiv: Eintrag löschen entfernt ihn dauerhaft', async ({ page }) => {
   await page.goto('/');
   await fillValid(page);
   const dl = page.waitForEvent('download');
@@ -129,6 +130,7 @@ test('Verlauf: Eintrag löschen entfernt ihn dauerhaft', async ({ page }) => {
   await dl;
   await expect(page.locator('#successOverlay')).toBeHidden({ timeout: 5000 });
 
+  page.on('dialog', (d) => d.accept()); // Lösch-Bestätigung
   await page.click('.hist-del');
   await expect(page.locator('#historyCard')).toBeHidden();
   await page.reload();


### PR DESCRIPTION
## 📁 Archiv – fertige Dokus inkl. Fotos speichern

Bisher merkte sich die App nur Text als Vorlage – die **Fotos waren nach dem Teilen weg**. Das war die größte Lücke. Jetzt gibt es ein echtes Archiv.

### Was es kann
- Jede erstellte/geteilte Doku wird **komplett gespeichert** (alle Felder **+ Fotos**) – lokal in IndexedDB (localStorage wäre für Bilder zu klein), bis zu 40 Einträge.
- Die Archiv-Karte zeigt jeden Eintrag mit **Foto-Vorschau**, Titel, Kunde/AB/Datum und Foto-Anzahl.
- Pro Eintrag drei Aktionen:
  - **Antippen** → komplette Doku **inkl. Fotos** zurück ins Formular laden (bearbeiten oder neu teilen)
  - **📄** → direkt erneut als PDF teilen/speichern (ohne Umweg)
  - **🗑** → löschen (mit Rückfrage)

### Technik
- `js/archive.js` – schlanker IndexedDB-Wrapper (rein lokal, offline)
- `finalize()` legt die vollständige Doku beim PDF/Teilen ins Archiv
- Der alte Text-Verlauf (localStorage) wurde dadurch ersetzt
- Privat-Icon im Archiv ergänzt; im Service-Worker gecacht, SW-Cache erhöht

### Qualität
- Tests auf Archiv umgestellt: erscheint nach PDF, **überlebt Reload** (IndexedDB), **Laden inkl. Fotos**, Löschen dauerhaft
- **56 Tests gesamt, alle grün**, visuell verifiziert

> Nächster Schritt (separater PR): ✍️ Unterschrift im PDF.

https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S)_