### PR TITLE
✍️ Unterschrift mit dem Finger – im PDF, Archiv & Entwurf

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -477,6 +477,19 @@ input.ok-flash, textarea.ok-flash { border-color: var(--ok); animation: okPulse 
   width: 18px; height: 18px; border-radius: 50%; display: grid; place-items: center; pointer-events: none;
 }
 
+/* ===== Unterschrift ===== */
+.sig-preview-wrap {
+  background: #fff; border: 1px solid var(--border); border-radius: var(--radius-sm);
+  padding: 8px; margin-bottom: 10px; display: grid; place-items: center;
+}
+.sig-preview-wrap img { max-width: 100%; max-height: 110px; }
+.sig-wrap {
+  width: 100%; max-width: 560px; height: 46vh; background: #fff;
+  border-radius: 10px; box-shadow: var(--shadow-lg); overflow: hidden;
+}
+#sigCanvas { display: block; touch-action: none; width: 100%; height: 100%; }
+.sig-hint { background: #0f1828; color: #93c5fd; font-size: 12.5px; padding: 8px 14px; text-align: center; }
+
 /* ===== Buttons ===== */
 .btn {
   position: relative; overflow: hidden; /* für Ripple-Effekt */

--- a/index.html
+++ b/index.html
@@ -232,6 +232,17 @@
       </div>
 
       <div class="card">
+        <div class="card-title"><span class="num">✍️</span> Unterschrift <span class="count">optional</span></div>
+        <div class="sig-preview-wrap hidden" id="sigPreviewWrap">
+          <img id="sigPreview" alt="Unterschrift">
+        </div>
+        <div class="btn-row">
+          <button class="btn btn-ghost" id="sigOpen" type="button">✍️ Unterschreiben</button>
+          <button class="btn btn-ghost hidden" id="sigDelete" type="button">🗑 Entfernen</button>
+        </div>
+      </div>
+
+      <div class="card">
         <div class="card-title"><span class="num">4</span> Fotos <span class="count" id="photoCount">0 / 9</span></div>
         <div class="photo-actions" id="photoArea">
           <label class="photo-add" for="galleryInput">
@@ -309,6 +320,18 @@
     <div class="canvas-wrap"><canvas id="zoneCanvas"></canvas></div>
     <div class="zone-list" id="zoneList"></div>
     <input type="file" id="zoneInput" accept="image/*" class="sr-only" aria-label="Foto der Arbeitskarte wählen">
+  </div>
+
+  <!-- Unterschrift-Pad -->
+  <div class="modal" id="sigModal" role="dialog" aria-modal="true" aria-label="Unterschrift">
+    <div class="modal-head">
+      <button id="sigCancel" type="button">✕ Abbrechen</button>
+      <h2>Unterschrift</h2>
+      <button id="sigSave" type="button" style="background:#16a34a">✓ Übernehmen</button>
+    </div>
+    <div class="sig-hint">Mit dem Finger im weißen Feld unterschreiben.</div>
+    <div class="canvas-wrap"><div class="sig-wrap"><canvas id="sigCanvas"></canvas></div></div>
+    <div class="zone-bar"><button class="zone-btn" id="sigClear" type="button">🗑 Löschen</button></div>
   </div>
 
   <!-- Vollbild-Vorschau -->

--- a/js/app.js
+++ b/js/app.js
@@ -5,6 +5,7 @@ import { annotate } from './annotate.js';
 import { scanArbeitskarte } from './scan.js';
 import { openZoneCalibrator } from './zonecal.js';
 import { zoneLabel } from './zones.js';
+import { openSignaturePad } from './signature.js';
 
 const $ = (id) => document.getElementById(id);
 const MAX_IMAGES = 9;
@@ -19,6 +20,7 @@ function requiredFor(typ) { return typ === 'Privat' ? REQUIRED_PRIVAT : REQUIRED
 const DRAFT_FIELDS = ['auftragstyp', 'kunde', 'maschine', 'abnr', 'position', 'zeichnungsnummer', 'index', 'verantwortlich', 'datum', 'teilebenennung', 'stueckzahl', 'version', 'spanndruck', 'bemerkung'];
 
 let images = []; // [{ id, src, name, caption }]
+let signature = ''; // Unterschrift als PNG-Daten-URL ('' = keine)
 
 /* ===================== Init ===================== */
 function init() {
@@ -38,6 +40,7 @@ function init() {
   initRipple();
   initInstall();
   initZones();
+  initSignature();
   refreshSuggestions();
   setToday();
   const last = Settings.get().lastVerantwortlich;
@@ -128,6 +131,25 @@ function refreshZoneStatus() {
   } else {
     el.textContent = '⚙️ Scan-Vorlage einrichten – Felder selbst festlegen';
   }
+}
+
+/* ===================== Unterschrift ===================== */
+function initSignature() {
+  $('sigOpen').onclick = async () => {
+    const r = await openSignaturePad(signature);
+    if (r === null) return;        // Abbruch → unverändert
+    signature = r;                 // '' = geleert übernommen, sonst Daten-URL
+    renderSignature(); saveDraft(); vibrate(10);
+  };
+  $('sigDelete').onclick = () => { signature = ''; renderSignature(); saveDraft(); };
+  renderSignature();
+}
+function renderSignature() {
+  const has = !!signature;
+  $('sigPreviewWrap').classList.toggle('hidden', !has);
+  $('sigDelete').classList.toggle('hidden', !has);
+  if (has) $('sigPreview').src = signature;
+  $('sigOpen').textContent = has ? '✍️ Ändern' : '✍️ Unterschreiben';
 }
 
 /* ===================== Service Worker (+ Update-Hinweis) ===================== */
@@ -410,7 +432,7 @@ function initVoice() {
 
 /* ===================== Formular <-> Daten ===================== */
 function readForm() {
-  const doc = { auftragstyp: currentType(), images: images.map((i) => ({ src: i.src, name: i.name, caption: i.caption })) };
+  const doc = { auftragstyp: currentType(), unterschrift: signature, images: images.map((i) => ({ src: i.src, name: i.name, caption: i.caption })) };
   ['kunde', 'maschine', 'abnr', 'position', 'zeichnungsnummer', 'index', 'verantwortlich', 'datum',
     'teilebenennung', 'stueckzahl', 'version', 'spanndruck', 'bemerkung'].forEach((f) => doc[f] = $(f).value);
   return doc;
@@ -423,6 +445,8 @@ function clearForm() {
     'stueckzahl', 'version', 'spanndruck', 'bemerkung'].forEach((f) => $(f).value = '');
   $('verantwortlich').value = Settings.get().lastVerantwortlich || '';
   images = [];
+  signature = '';
+  renderSignature();
   renderPhotos();
   setToday();
   clearAllErrors();
@@ -567,6 +591,7 @@ function saveDraft() {
   clearTimeout(draftTimer);
   draftTimer = setTimeout(() => {
     const fields = {}; DRAFT_FIELDS.forEach((f) => fields[f] = f === 'auftragstyp' ? currentType() : $(f).value);
+    fields.unterschrift = signature;
     Draft.save(fields);
   }, 600);
 }
@@ -585,8 +610,11 @@ function restoreDraft() {
   const f = d.fields;
   if (f.auftragstyp === 'Reklamation') $('typRekl').checked = true;
   else if (f.auftragstyp === 'Fertigungsauftrag') $('typFert').checked = true;
+  else if (f.auftragstyp === 'Privat') $('typPriv').checked = true;
   updateTypeFields(f.auftragstyp || '');
   DRAFT_FIELDS.filter((k) => k !== 'auftragstyp').forEach((k) => { if (f[k] != null) $(k).value = f[k]; });
+  signature = f.unterschrift || '';
+  renderSignature();
   const t = new Date(d.savedAt);
   $('draftText').textContent = `Entwurf von ${String(t.getHours()).padStart(2, '0')}:${String(t.getMinutes()).padStart(2, '0')} wiederhergestellt (Fotos bitte erneut hinzufügen).`;
   $('draftBanner').classList.remove('hidden');
@@ -665,6 +693,8 @@ function loadArchiveEntry(entry) {
   images = (entry.images || []).map((im, i) => ({
     id: 'img_' + Date.now() + '_' + i, src: im.src, name: im.name || ('Bild' + (i + 1)), caption: im.caption || '',
   }));
+  signature = f.unterschrift || '';
+  renderSignature();
   renderPhotos();
   clearAllErrors();
   saveDraft();

--- a/js/pdf.js
+++ b/js/pdf.js
@@ -198,6 +198,23 @@ function remarksBlock(pdf, doc, startY, created) {
   return y + 4;
 }
 
+/* ---------------- Unterschrift / Freigabe ---------------- */
+function signatureBlock(pdf, doc, startY) {
+  let y = startY + 5;
+  if (y > PH - 48) { pdf.addPage(); header(pdf, doc); y = BAND + 12; }
+  y = sectionTitle(pdf, 'Freigabe / Unterschrift', y) + 3;
+  try {
+    pdf.addImage(doc.unterschrift, 'PNG', M, y, 55, 22, undefined, 'FAST');
+  } catch { /* ungültiges Bild ignorieren */ }
+  y += 24;
+  pdf.setDrawColor(...C_LINE); pdf.setLineWidth(0.3);
+  pdf.line(M, y, M + 70, y);
+  pdf.setFont('helvetica', 'normal'); pdf.setFontSize(8); pdf.setTextColor(...C_MUTED);
+  const who = doc.verantwortlich || '';
+  pdf.text(`${who}${who ? ' · ' : ''}${fmtDate(doc.datum)}`, M, y + 5);
+  return y + 8;
+}
+
 /* ---------------- Foto-Seiten ---------------- */
 function layoutFor(n) {
   if (n <= 1) return { cols: 1, rows: 1 };
@@ -268,7 +285,8 @@ export async function createPDF(doc) {
   header(pdf, doc);
   let y = sectionTitle(pdf, 'Auftragsdaten', BAND + 9);
   y = metaTable(pdf, doc, y + 1);
-  remarksBlock(pdf, doc, y, created);
+  y = remarksBlock(pdf, doc, y, created);
+  if (doc.unterschrift) signatureBlock(pdf, doc, y);
 
   // Bilder laden (defekte überspringen)
   const imgs = [];

--- a/js/signature.js
+++ b/js/signature.js
@@ -1,0 +1,88 @@
+// Unterschrift-Pad: mit dem Finger (oder Maus) unterschreiben.
+// Liefert eine PNG-Daten-URL (oder '' wenn leer übernommen, oder null bei Abbruch).
+let canvas, ctx, resolveFn, drawn, dpr;
+
+function $(id) { return document.getElementById(id); }
+
+function setup() {
+  canvas = $('sigCanvas');
+  ctx = canvas.getContext('2d');
+  $('sigClear').onclick = clearPad;
+  $('sigCancel').onclick = () => close(null);
+  $('sigSave').onclick = () => close(drawn ? canvas.toDataURL('image/png') : '');
+  bindPointer();
+  setup.done = true;
+}
+
+function fitCanvas() {
+  const wrap = canvas.parentElement;
+  dpr = window.devicePixelRatio || 1;
+  const w = wrap.clientWidth, h = wrap.clientHeight;
+  canvas.width = Math.round(w * dpr);
+  canvas.height = Math.round(h * dpr);
+  canvas.style.width = w + 'px';
+  canvas.style.height = h + 'px';
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  paintBg();
+}
+
+function paintBg() {
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.restore();
+}
+
+function clearPad() { drawn = false; paintBg(); }
+
+function pos(e) {
+  const r = canvas.getBoundingClientRect();
+  return { x: e.clientX - r.left, y: e.clientY - r.top };
+}
+
+function bindPointer() {
+  let active = false, last = null;
+  canvas.addEventListener('pointerdown', (e) => {
+    active = true; canvas.setPointerCapture(e.pointerId); last = pos(e);
+    ctx.beginPath(); ctx.moveTo(last.x, last.y);
+  });
+  canvas.addEventListener('pointermove', (e) => {
+    if (!active) return;
+    const p = pos(e);
+    ctx.strokeStyle = '#0b1b2b';
+    ctx.lineWidth = 2.4; ctx.lineCap = 'round'; ctx.lineJoin = 'round';
+    ctx.lineTo(p.x, p.y); ctx.stroke();
+    last = p; drawn = true;
+  });
+  const end = () => { active = false; };
+  canvas.addEventListener('pointerup', end);
+  canvas.addEventListener('pointercancel', end);
+}
+
+function close(result) {
+  $('sigModal').classList.remove('open');
+  document.body.style.overflow = '';
+  const r = resolveFn; resolveFn = null;
+  r && r(result);
+}
+
+// Öffnet das Pad. existing (Daten-URL) wird als Startbild geladen.
+export function openSignaturePad(existing) {
+  return new Promise((resolve) => {
+    if (!setup.done) setup();
+    resolveFn = resolve;
+    drawn = false;
+    $('sigModal').classList.add('open');
+    document.body.style.overflow = 'hidden';
+    // nach dem Öffnen messen (Layout steht erst dann)
+    requestAnimationFrame(() => {
+      fitCanvas();
+      if (existing) {
+        const img = new Image();
+        img.onload = () => { ctx.drawImage(img, 0, 0, canvas.width / dpr, canvas.height / dpr); drawn = true; };
+        img.src = existing;
+      }
+    });
+  });
+}

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-15';
+const CACHE = 'techdoku-v2026-16';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier
@@ -18,6 +18,7 @@ const ASSETS = [
   './js/zones.js',
   './js/zonecal.js',
   './js/archive.js',
+  './js/signature.js',
   './vendor/jspdf.umd.min.js',
   './manifest.json',
   './icon-192.png',

--- a/tests/extras.spec.js
+++ b/tests/extras.spec.js
@@ -62,6 +62,43 @@ test('Install-Banner: Schließen merkt sich die Entscheidung', async ({ page }) 
   await expect(page.locator('#installCard')).toBeHidden();
 });
 
+async function sign(page) {
+  await page.click('#sigOpen');
+  await expect(page.locator('#sigModal')).toHaveClass(/open/);
+  const box = await page.locator('#sigCanvas').boundingBox();
+  await page.mouse.move(box.x + box.width * 0.2, box.y + box.height * 0.5);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width * 0.5, box.y + box.height * 0.3);
+  await page.mouse.move(box.x + box.width * 0.8, box.y + box.height * 0.6);
+  await page.mouse.up();
+  await page.click('#sigSave');
+  await expect(page.locator('#sigModal')).not.toHaveClass(/open/);
+}
+
+test('Unterschrift: zeichnen zeigt Vorschau; landet im Archiv und wird geladen', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(2300); // Splash weg
+
+  await sign(page);
+  await expect(page.locator('#sigPreviewWrap')).toBeVisible();
+  const src = await page.locator('#sigPreview').getAttribute('src');
+  expect(src).toContain('data:image/png');
+
+  // Doku abschließen → ins Archiv
+  await fillValid(page);
+  const dl = page.waitForEvent('download');
+  await page.click('#btnPdf');
+  await dl;
+  await expect(page.locator('#successOverlay')).toBeHidden({ timeout: 5000 });
+
+  // Neu, dann aus Archiv laden → Unterschrift ist wieder da
+  page.on('dialog', (d) => d.accept());
+  await page.click('#btnNew');
+  await expect(page.locator('#sigPreviewWrap')).toBeHidden();
+  await page.click('.hist-main');
+  await expect(page.locator('#sigPreviewWrap')).toBeVisible();
+});
+
 test('gültig befülltes Pflichtfeld bekommt einen grünen Impuls', async ({ page }) => {
   await page.goto('/');
   await page.fill('#kunde', 'Andritz Hydro GmbH');


### PR DESCRIPTION
## ✍️ Unterschrift – mit dem Finger unterschreiben

Zweites gewünschtes Feature: am Ende mit dem Finger unterschreiben, die Unterschrift kommt direkt ins PDF. Typisch für QS-/Freigabe-Dokumente.

### Was es kann
- **Unterschrift-Karte** im Formular (optional) mit Button **„✍️ Unterschreiben"**.
- Öffnet ein **Pad** mit weißem Feld – mit Finger oder Maus unterschreiben, **Löschen / Abbrechen / Übernehmen** (scharf dank HiDPI).
- Danach **Vorschau** im Formular mit **„Ändern"** und **„Entfernen"**.
- Die Unterschrift erscheint im **PDF** als eigener Block **„Freigabe / Unterschrift"** (Bild + Name + Datum).
- Wird im **Archiv** mitgespeichert und beim Laden wiederhergestellt; auch im **Entwurf** gesichert (geht bei versehentlichem Schließen nicht verloren).

### Bonus-Fix
Der Entwurf stellt jetzt auch den Auftragstyp **„Privat"** korrekt wieder her (vorher nur Reklamation/Fertigung).

### Qualität
- `js/signature.js` (eigenständiges Pad-Modul), im Service-Worker gecacht
- Test: zeichnen → Vorschau erscheint → landet im Archiv → wird beim Laden wiederhergestellt
- **58 Tests gesamt, alle grün**, Pad + Vorschau visuell verifiziert
- SW-Cache-Version erhöht

https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S)_