### PR TITLE
🔍 Review-Durchgang: Privat-Ring & Unterschrift-Fixes + Politur

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -374,7 +374,7 @@ function renderPhotos() {
     el.className = 'thumb' + (im.caption ? ' has-caption' : '');
     el.innerHTML = `
       <span class="badge">${i + 1}</span>
-      <img src="${im.src}" alt="Foto ${i + 1}${im.caption ? ': ' + esc(im.caption) : ''}">
+      <img src="${im.src}" alt="Foto ${i + 1}${im.caption ? ': ' + esc(im.caption) : ''}" loading="lazy" decoding="async">
       <div class="tools">
         <button data-act="left" title="Nach vorne" aria-label="Nach vorne"${i === 0 ? ' disabled' : ''}>◀</button>
         <button data-act="edit" title="Markieren" aria-label="Markieren">✎</button>
@@ -660,7 +660,7 @@ async function renderArchive() {
     row.className = 'hist-row';
     row.innerHTML = `
       <button class="hist-main" type="button">
-        ${thumb ? `<img class="hist-thumb" src="${thumb}" alt="">` : `<span class="hist-ico">${TYPE_ICON[f.auftragstyp] || '📄'}</span>`}
+        ${thumb ? `<img class="hist-thumb" src="${thumb}" alt="" loading="lazy" decoding="async">` : `<span class="hist-ico">${TYPE_ICON[f.auftragstyp] || '📄'}</span>`}
         <span class="hist-txt">
           <strong>${esc(f.teilebenennung || f.kunde || 'Dokumentation')}</strong>
           <small>${esc([f.kunde, f.abnr, when].filter(Boolean).join(' · '))}${nPhotos ? ` · ${nPhotos} 📷` : ''}</small>
@@ -723,12 +723,13 @@ async function sharePdfFromEntry(entry) {
 }
 
 /* ===================== Fortschrittsanzeige ===================== */
-// Zählt Auftragstyp, Pflichtfelder (inkl. typabhängiger) und Fotos.
+// Zählt Auftragstyp, die je nach Typ tatsächlich nötigen Pflichtfelder und
+// Fotos – passend zu validate(), damit der Ring auch bei "Privat" 100% erreicht.
 function progressParts() {
-  const parts = [!!currentType()];
-  REQUIRED.forEach((f) => parts.push(!!$(f).value.trim()));
-  parts.push(Number($('stueckzahl').value) > 0);
   const typ = currentType();
+  const parts = [!!typ];
+  requiredFor(typ).forEach((f) => parts.push(!!$(f).value.trim()));
+  if (typ !== 'Privat') parts.push(Number($('stueckzahl').value) > 0);
   if (typ === 'Reklamation') parts.push(!!$('version').value.trim());
   if (typ === 'Fertigungsauftrag') parts.push(!!$('spanndruck').value.trim());
   parts.push(images.length > 0);

--- a/js/signature.js
+++ b/js/signature.js
@@ -80,7 +80,14 @@ export function openSignaturePad(existing) {
       fitCanvas();
       if (existing) {
         const img = new Image();
-        img.onload = () => { ctx.drawImage(img, 0, 0, canvas.width / dpr, canvas.height / dpr); drawn = true; };
+        img.onload = () => {
+          // In echten Geräte-Pixeln zeichnen (transform-unabhängig, HiDPI-korrekt)
+          ctx.save();
+          ctx.setTransform(1, 0, 0, 1, 0, 0);
+          ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+          ctx.restore();
+          drawn = true;
+        };
         img.src = existing;
       }
     });

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-16';
+const CACHE = 'techdoku-v2026-17';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -105,6 +105,9 @@ test('Privat: blendet Fertigungsfelder aus und erstellt PDF ohne Pflicht-AB-Nr.'
   await page.setInputFiles('#galleryInput', { name: 'p.png', mimeType: 'image/png', buffer: PNG });
   await expect(page.locator('#photoGrid .thumb')).toHaveCount(1);
 
+  // Fortschrittsring erreicht im Privat-Modus 100% (zählt nur nötige Felder)
+  await expect(page.locator('#progressPct')).toHaveText('100%');
+
   const dl = page.waitForEvent('download');
   await page.click('#btnPdf');
   const download = await dl;


### PR DESCRIPTION
## 🔍 Review-Durchgang: Fixes + Politur

Kompletter Durchgang über die App nach den vielen neuen Features. Zwei echte Bugs gefunden und behoben, plus etwas Politur.

### Behobene Fehler
- **Fortschrittsring bei „Privat"** – zählte die ausgeblendeten Fertigungsfelder mit und erreichte daher nie 100 %. Jetzt typ-abhängig (nutzt dieselbe Logik wie die Validierung) → erreicht im Privat-Modus korrekt 100 %.
- **Unterschrift auf hochauflösenden Displays** – beim erneuten Öffnen einer gespeicherten Unterschrift wurde sie auf Retina-Geräten verzerrt/zu groß gezeichnet. Jetzt geräte-pixel-korrekt.

### Politur
- Archiv- und Foto-Vorschaubilder laden **verzögert** (`loading=lazy`, `decoding=async`) → flüssiger bei vielen Bildern.

### Geprüft & sauber
- Keine toten Referenzen (History/setTodayForce o.ä. sauber entfernt)
- Validierung, PDF-Blöcke (Bemerkungen → Unterschrift), Archiv-Speicher, Zonen-OCR – alles konsistent
- Neuer Test sichert den Privat-Ring (100 %) ab
- **58 Tests gesamt, alle grün**, SW-Cache erhöht

https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S)_