### PR TITLE
🔄 Auto-Update: App lädt neue Version automatisch (Cache-Problem behoben)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -156,11 +156,28 @@ function renderSignature() {
 function registerSW() {
   if (!('serviceWorker' in navigator)) return;
   const hadController = !!navigator.serviceWorker.controller;
-  navigator.serviceWorker.register('sw.js').catch(() => {});
-  let notified = false;
+  navigator.serviceWorker.register('sw.js').then((reg) => {
+    // regelmäßig auf neue Version prüfen (App bleibt oft lange offen)
+    setInterval(() => reg.update().catch(() => {}), 60 * 60 * 1000);
+  }).catch(() => {});
+  let refreshing = false;
   navigator.serviceWorker.addEventListener('controllerchange', () => {
-    if (hadController && !notified) { notified = true; actionToast('Neue Version verfügbar – tippen zum Aktualisieren', () => location.reload()); }
+    if (!hadController || refreshing) return; // beim Erst-Install nicht neu laden
+    refreshing = true;
+    // Nichts Wichtiges offen? Dann automatisch aktualisieren – sonst Hinweis,
+    // damit keine ungespeicherten Fotos verloren gehen.
+    if (isFormDirty()) {
+      refreshing = false;
+      actionToast('Neue Version verfügbar – tippen zum Aktualisieren', () => location.reload());
+    } else {
+      location.reload();
+    }
   });
+}
+// "Dirty" = es gibt ungesicherte Eingaben/Fotos, die ein Reload verlieren würde
+function isFormDirty() {
+  return images.length > 0 || !!signature ||
+    ['kunde', 'teilebenennung', 'bemerkung', 'abnr'].some((id) => $(id) && $(id).value.trim());
 }
 
 /* ===================== Theme ===================== */

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-17';
+const CACHE = 'techdoku-v2026-18';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier


### PR DESCRIPTION
## 🔄 Auto-Update – Schluss mit „sieht alles alt aus"

**Ursache des Problems:** Die App war technisch aktuell (Archiv, Unterschrift, Privat sind alle live deployt – geprüft am ausgelieferten `index.html`), aber auf dem Handy lief die **alte Version aus dem Cache**. Der bisherige Update-Hinweis („Neue Version verfügbar – tippen") wurde leicht übersehen, also blieb man auf dem alten Stand und das Archiv „fehlte".

### Lösung
- Der Service Worker prüft jetzt **stündlich** auf eine neue Version.
- Sobald eine neue Version bereitsteht und **nichts Ungesichertes offen ist**, lädt die App **automatisch** neu auf den aktuellen Stand – ohne Zutun.
- Nur wenn man gerade mitten in Eingaben/Fotos steckt, kommt stattdessen der Hinweis zum Antippen (damit nichts verloren geht).
- Erst-Installation löst kein Reload aus.

Ab jetzt bekommst du neue Funktionen automatisch, ohne Cache-Tricks.

### Wichtig für JETZT (einmalig)
Dieses Auto-Update muss erst einmal selbst ankommen. Damit du den aktuellen Stand **jetzt** siehst:
- App **komplett schließen** (aus dem App-Umschalter wegwischen) und neu öffnen – am besten 2×. Danach aktualisiert sie sich künftig allein.

### Hinweis zum Archiv
Die **Archiv**-Karte erscheint erst, **nachdem du die erste Doku als PDF erstellt/geteilt** hast – dann taucht sie mit Foto-Vorschau auf.

**58 Tests grün**, SW-Cache erhöht.

https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S)_