### PR TITLE
🤖 Start-Animation: Explosionszeichnung montiert sich (Blueprint-Skizze)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -72,36 +72,48 @@ body {
     radial-gradient(120% 90% at 50% 0%, #0e7490 0%, transparent 55%),
     linear-gradient(155deg, var(--accent-dark), var(--accent-strong) 55%, #07314a);
   color: #fff; pointer-events: none; /* blockiert keine Klicks */
-  animation: splashOut .5s ease 1.25s forwards;
+  animation: splashOut .5s ease 1.85s forwards;
 }
 .splash-inner {
   display: flex; flex-direction: column; align-items: center; gap: 10px;
   animation: splashRise .6s cubic-bezier(.2, .8, .2, 1) both;
 }
 
-/* --- Animierte technische Grafik (Zahnräder + Radar + Mess-Punkte) --- */
-.splash-graphic { position: relative; width: 150px; height: 150px; filter: drop-shadow(0 14px 36px rgba(0,0,0,.4)); }
+/* --- Animierte Explosionszeichnung (Montage in Skizzen-/Blueprint-Optik) --- */
+.splash-graphic { position: relative; width: 200px; height: 150px; filter: drop-shadow(0 14px 36px rgba(0,0,0,.4)); }
 .splash-graphic > svg { width: 100%; height: 100%; overflow: visible; }
-/* Logo zentral über der SVG */
-.splash-core { position: absolute; inset: 0; display: grid; place-items: center; }
-.splash-core-tile {
-  width: 44px; height: 44px; border-radius: 13px; background: #fff;
-  display: grid; place-items: center; box-shadow: 0 6px 18px rgba(0,0,0,.3);
-  animation: coreBob 1.8s ease-in-out infinite;
+/* Grundlinien-Stil: dünne helle Linien, keine Füllung (technische Zeichnung) */
+.ex { fill: none; stroke: #cfe8ff; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.ex-grid { stroke: #7dd3fc; stroke-width: 1; opacity: .12; }
+.ex-bolt, .ex-nut { stroke: #eaf6ff; }
+.ex-plate { stroke: #bfe3ff; }
+.ex-wA, .ex-wB { stroke: #7dd3fc; }
+/* Montage-Achse zeichnet sich ein */
+.ex-axis { stroke: #5cc6f5; stroke-width: 1.5; stroke-dasharray: 4 4; stroke-dashoffset: 200; opacity: .9; animation: exAxis 1s ease .1s both; }
+@keyframes exAxis { to { stroke-dashoffset: 0; } }
+/* Teile fliegen aus der Explosionslage in die Montageposition */
+.ex-part { opacity: 0; }
+.ex-bolt  { animation: exBolt  .7s cubic-bezier(.34,1.45,.5,1) .15s both; }
+.ex-wA    { animation: exWA    .7s cubic-bezier(.34,1.45,.5,1) .30s both; }
+.ex-plate { animation: exPlate .7s cubic-bezier(.34,1.45,.5,1) .45s both; }
+.ex-wB    { animation: exWB    .7s cubic-bezier(.34,1.45,.5,1) .60s both; }
+.ex-nut   { animation: exNut   .75s cubic-bezier(.34,1.45,.5,1) .72s both; }
+@keyframes exBolt  { from { opacity: 0; transform: translate(-44px, 0); } to { opacity: 1; transform: none; } }
+@keyframes exWA    { from { opacity: 0; transform: translate(0, 44px); } to { opacity: 1; transform: none; } }
+@keyframes exPlate { from { opacity: 0; transform: translate(0, -52px); } to { opacity: 1; transform: none; } }
+@keyframes exWB    { from { opacity: 0; transform: translate(0, 44px); } to { opacity: 1; transform: none; } }
+@keyframes exNut   { from { opacity: 0; transform: translate(46px, 0); } to { opacity: 1; transform: none; } }
+/* Bemaßung blendet ein, wenn alles sitzt */
+.ex-dim { stroke: #9fd8f5; stroke-width: 1; opacity: 0; animation: exDim .5s ease 1.25s both; }
+@keyframes exDim { to { opacity: .75; } }
+/* Scan-Strahl wandert über die fertige Baugruppe */
+.ex-scan { stroke: #38bdf8; stroke-width: 2; opacity: 0; animation: exScan 2.4s ease-in-out 1.4s infinite; }
+@keyframes exScan {
+  0% { transform: translateX(28px); opacity: 0; }
+  18% { opacity: .55; }
+  82% { opacity: .55; }
+  100% { transform: translateX(150px); opacity: 0; }
 }
-.sp-core-gear { transform-box: fill-box; transform-origin: center; animation: spinRev 5s linear infinite; }
-/* Alle drehenden Teile rotieren um die SVG-Mitte (70,70) */
-.sp-spin { transform-box: view-box; transform-origin: 70px 70px; }
-.sp-gear-out { animation: spin 9s linear infinite; }
-.sp-gear-mid { animation: spinRev 6s linear infinite; }
-.sp-scale    { animation: spin 14s linear infinite; }
-.sp-orbit    { animation: spin 4.5s linear infinite; }
-.sp-sweep    { animation: spin 2.4s linear infinite; }
-.sp-pulse    { transform-box: view-box; transform-origin: 70px 70px; animation: corePulse 1.8s ease-out infinite; }
-@keyframes spin { to { transform: rotate(360deg); } }
-@keyframes spinRev { to { transform: rotate(-360deg); } }
-@keyframes corePulse { 0% { transform: scale(.85); opacity: .8; } 100% { transform: scale(1.7); opacity: 0; } }
-@keyframes coreBob { 50% { transform: scale(1.06); } }
 .splash-title { font-size: 19px; font-weight: 800; letter-spacing: -.01em; margin-top: 6px; }
 .splash-sub { font-size: 12.5px; opacity: .85; letter-spacing: .03em; }
 .splash-bar {

--- a/index.html
+++ b/index.html
@@ -22,51 +22,40 @@
   <div class="splash" id="splash" aria-hidden="true">
     <div class="splash-inner">
       <div class="splash-graphic">
-        <svg viewBox="0 0 140 140" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <defs>
-            <linearGradient id="sweepGrad" x1="70" y1="70" x2="134" y2="70" gradientUnits="userSpaceOnUse">
-              <stop offset="0" stop-color="#38bdf8" stop-opacity="0"/>
-              <stop offset="1" stop-color="#38bdf8" stop-opacity=".55"/>
-            </linearGradient>
-          </defs>
+        <svg class="ex" viewBox="0 0 200 150" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <!-- feines Konstruktionsraster -->
+          <g class="ex-grid">
+            <line x1="20" y1="45" x2="180" y2="45"/><line x1="20" y1="75" x2="180" y2="75"/><line x1="20" y1="105" x2="180" y2="105"/>
+            <line x1="50" y1="25" x2="50" y2="125"/><line x1="100" y1="25" x2="100" y2="125"/><line x1="150" y1="25" x2="150" y2="125"/>
+          </g>
+          <!-- Montage-Achse -->
+          <line class="ex-axis" x1="26" y1="75" x2="176" y2="75"/>
 
-          <!-- Radar-Suchstrahl -->
-          <g class="sp-spin sp-sweep">
-            <path d="M70 70 L134 70 A64 64 0 0 1 102 125.4 Z" fill="url(#sweepGrad)"/>
+          <!-- Schraube (Kopf + Schaft) -->
+          <g class="ex-part ex-bolt">
+            <polygon points="35,75 39.5,67.2 48.5,67.2 53,75 48.5,82.8 39.5,82.8"/>
+            <rect x="50" y="71.5" width="26" height="7"/>
+            <line x1="58" y1="71.5" x2="58" y2="78.5"/><line x1="63" y1="71.5" x2="63" y2="78.5"/><line x1="68" y1="71.5" x2="68" y2="78.5"/>
+          </g>
+          <!-- Unterlegscheibe A -->
+          <g class="ex-part ex-wA"><circle cx="82" cy="75" r="6"/><circle cx="82" cy="75" r="3"/></g>
+          <!-- Platte -->
+          <g class="ex-part ex-plate"><rect x="90" y="50" width="12" height="50" rx="2"/><circle cx="96" cy="75" r="3.8"/></g>
+          <!-- Unterlegscheibe B -->
+          <g class="ex-part ex-wB"><circle cx="112" cy="75" r="6"/><circle cx="112" cy="75" r="3"/></g>
+          <!-- Mutter -->
+          <g class="ex-part ex-nut"><polygon points="121,75 125.5,67.2 134.5,67.2 139,75 134.5,82.8 125.5,82.8"/><circle cx="130" cy="75" r="4.2"/></g>
+
+          <!-- Bemassung -->
+          <g class="ex-dim">
+            <line x1="40" y1="120" x2="130" y2="120"/>
+            <line x1="40" y1="116" x2="40" y2="124"/><line x1="130" y1="116" x2="130" y2="124"/>
+            <polyline points="44,117.5 40,120 44,122.5"/><polyline points="126,117.5 130,120 126,122.5"/>
           </g>
 
-          <!-- Äußeres Zahnrad (grobe Zähne) -->
-          <circle class="sp-spin sp-gear-out" cx="70" cy="70" r="60" stroke="#bfe3ff" stroke-opacity=".85" stroke-width="7" stroke-dasharray="7 9.4"/>
-          <!-- Mittleres Zahnrad, gegenläufig -->
-          <circle class="sp-spin sp-gear-mid" cx="70" cy="70" r="45" stroke="#5cc6f5" stroke-width="6" stroke-dasharray="5 7.5"/>
-          <!-- Feine Skala innen -->
-          <circle class="sp-spin sp-scale" cx="70" cy="70" r="32" stroke="#e6f6ff" stroke-opacity=".5" stroke-width="2" stroke-dasharray="1.5 4.5"/>
-
-          <!-- Pulsierender Ring -->
-          <circle class="sp-pulse" cx="70" cy="70" r="34" stroke="#4ade80" stroke-width="2" fill="none"/>
-
-          <!-- Umlaufende Mess-Punkte -->
-          <g class="sp-spin sp-orbit">
-            <circle cx="70" cy="12" r="3.4" fill="#7dd3fc"/>
-            <circle cx="119.8" cy="99" r="3" fill="#4ade80"/>
-            <circle cx="20.2" cy="99" r="3" fill="#fbbf24"/>
-          </g>
+          <!-- Scan-Strahl -->
+          <line class="ex-scan" x1="0" y1="48" x2="0" y2="102"/>
         </svg>
-
-        <!-- Logo-Kachel exakt in der Mitte (eigene Ebene → sauber zentriert) -->
-        <div class="splash-core">
-          <div class="splash-core-tile">
-            <svg viewBox="0 0 24 24" width="30" height="30">
-              <path d="M3 5.5A1.5 1.5 0 0 1 4.5 4H13l5 5v9.5A1.5 1.5 0 0 1 16.5 20h-12A1.5 1.5 0 0 1 3 18.5v-13Z" fill="#005288"/>
-              <path d="M13 4v5h5" fill="#0a6cb0"/>
-              <g class="sp-core-gear">
-                <circle cx="10.5" cy="13.5" r="3.1" fill="none" stroke="#0a6cb0" stroke-width="1.6"/>
-                <path d="M10.5 11.1v-1M10.5 16.9v-1M8.1 13.5h-1M13.9 13.5h-1M8.8 11.8l-.7-.7M12.9 15.9l-.7-.7M12.2 11.8l.7-.7M8.1 15.9l.7-.7" stroke="#0a6cb0" stroke-width="1.2" stroke-linecap="round"/>
-              </g>
-              <circle cx="10.5" cy="13.5" r="1" fill="#005288"/>
-            </svg>
-          </div>
-        </div>
       </div>
       <div class="splash-title">Technische Dokumentation</div>
       <div class="splash-sub">S. Fritz · Qualitätssicherung</div>

--- a/js/app.js
+++ b/js/app.js
@@ -56,7 +56,7 @@ function initSplash() {
   const el = $('splash');
   if (!el) return;
   const remove = () => { el.classList.add('gone'); setTimeout(() => el.remove(), 400); };
-  setTimeout(remove, 1800);
+  setTimeout(remove, 2400);
 }
 
 /* ===================== App installieren ===================== */

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-18';
+const CACHE = 'techdoku-v2026-19';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -48,7 +48,7 @@ test('lädt ohne Konsolenfehler und zeigt die Überschrift', async ({ page }) =>
   await page.waitForTimeout(300);
   expect(errors).toEqual([]);
   // Splash blendet weg und wird aus dem DOM entfernt (blockiert nie Klicks)
-  await expect(page.locator('#splash')).toHaveCount(0, { timeout: 3000 });
+  await expect(page.locator('#splash')).toHaveCount(0, { timeout: 4000 });
 });
 
 test('Validierung markiert leere Pflichtfelder', async ({ page }) => {

--- a/tests/extras.spec.js
+++ b/tests/extras.spec.js
@@ -77,7 +77,7 @@ async function sign(page) {
 
 test('Unterschrift: zeichnen zeigt Vorschau; landet im Archiv und wird geladen', async ({ page }) => {
   await page.goto('/');
-  await page.waitForTimeout(2300); // Splash weg
+  await page.waitForTimeout(2600); // Splash weg
 
   await sign(page);
   await expect(page.locator('#sigPreviewWrap')).toBeVisible();

--- a/tests/zones.spec.js
+++ b/tests/zones.spec.js
@@ -65,7 +65,7 @@ async function loadBigPhoto(page) {
 
 test('Scan-Vorlage: Kästchen ziehen, speichern und Status anzeigen', async ({ page }) => {
   await page.goto('/');
-  await page.waitForTimeout(2300); // Splash entfernt
+  await page.waitForTimeout(2600); // Splash entfernt
 
   await page.click('#zoneSetup');
   await expect(page.locator('#zoneModal')).toHaveClass(/open/);


### PR DESCRIPTION
## 🤖 Start-Animation: Explosionszeichnung montiert sich

Genau dein Wunsch: Statt der drehenden Zahnräder läuft beim Start jetzt eine **technische Montage-Simulation** wie eine **Explosionszeichnung in Skizzenform**.

### Was passiert
- **Schraube · Unterlegscheibe · Platte · Unterlegscheibe · Mutter** fliegen aus der Explosionslage entlang der **Montage-Achse** zusammen.
- **Blueprint-Optik:** dünne Linien (keine Flächen), feines **Konstruktionsraster**, **Bemaßung** mit Pfeilen, und ein durchlaufender **Scan-Strahl** über der fertigen Baugruppe.
- Die Achse **zeichnet sich** ein, Teile **rasten** mit leichtem Schwung in Position, dann blendet die Bemaßung ein.

### Technik
- Reine **SVG + CSS** (transform / stroke-dashoffset) – keine Abhängigkeit, voll offline
- Splash läuft ~2,3 s, damit die Montage sichtbar ist; danach geschmeidiger Übergang in die App
- `prefers-reduced-motion` respektiert (springt sauber in den fertig montierten Zustand)

**58 Tests grün**, Animation in mehreren Phasen visuell verifiziert. SW-Cache erhöht.

> Hinweis: Dank des neuen Auto-Updates kommt diese Animation nach dem Merge automatisch auf dein Handy (einmal App schließen & neu öffnen).

https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S)_