### PR TITLE
🖼️ Arbeitskarte auch aus Galerie scannen (nicht nur Kamera)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -237,6 +237,8 @@ main { max-width: 760px; margin: 0 auto; padding: 16px; }
 .scan-ico { font-size: 24px; line-height: 1; flex: 0 0 auto; }
 .scan-info strong { display: block; font-size: 15px; }
 .scan-info small { display: block; opacity: .9; font-size: 12.5px; margin-top: 2px; }
+.scan-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; position: relative; z-index: 1; }
+@media (max-width: 360px) { .scan-actions { grid-template-columns: 1fr; } }
 /* .btn.btn-scan: höhere Spezifität, damit die spätere .btn-Regel (color:#fff)
    die dunkle Schrift nicht überschreibt (sonst weiß auf weiß = unsichtbar) */
 .btn.btn-scan { background: #fff; color: var(--accent-strong); }

--- a/index.html
+++ b/index.html
@@ -101,11 +101,15 @@
           <span class="scan-ico" aria-hidden="true">⚡</span>
           <div>
             <strong>Arbeitskarte scannen</strong>
-            <small>Foto der Karte machen – Felder werden automatisch ausgefüllt (du prüfst sie).</small>
+            <small>Karte fotografieren oder aus der Galerie laden – Felder werden automatisch ausgefüllt (du prüfst sie).</small>
           </div>
         </div>
-        <label class="btn btn-scan" for="scanInput">📇 Karte scannen</label>
-        <input type="file" id="scanInput" accept="image/*" capture="environment" class="sr-only" aria-label="Arbeitskarte fotografieren oder wählen">
+        <div class="scan-actions">
+          <label class="btn btn-scan" for="scanInput">📷 Fotografieren</label>
+          <label class="btn btn-scan" for="scanGalleryInput">🖼️ Aus Galerie</label>
+        </div>
+        <input type="file" id="scanInput" accept="image/*" capture="environment" class="sr-only" aria-label="Arbeitskarte fotografieren">
+        <input type="file" id="scanGalleryInput" accept="image/*" class="sr-only" aria-label="Arbeitskarte aus Galerie wählen">
         <button class="scan-tpl" id="zoneSetup" type="button">
           <span id="zoneStatus">⚙️ Scan-Vorlage einrichten – Felder selbst festlegen</span>
         </button>

--- a/js/app.js
+++ b/js/app.js
@@ -2,7 +2,7 @@ import { Settings, Suggest, Draft, Zones } from './store.js';
 import { Archive } from './archive.js';
 import { createPDF, buildFilename } from './pdf.js';
 import { annotate } from './annotate.js';
-import { scanArbeitskarte } from './scan.js';
+import { scanArbeitskarte, prewarmScanner } from './scan.js';
 import { openZoneCalibrator } from './zonecal.js';
 import { zoneLabel } from './zones.js';
 import { openSignaturePad } from './signature.js';
@@ -282,18 +282,27 @@ function initScan() {
   };
   $('scanInput').addEventListener('change', onScanFile);
   $('scanGalleryInput').addEventListener('change', onScanFile);
+  // Erkennung schon laden, während der Nutzer Kamera/Galerie öffnet
+  ['scanInput', 'scanGalleryInput'].forEach((id) => {
+    const lbl = document.querySelector(`label[for=${id}]`);
+    if (lbl) lbl.addEventListener('pointerdown', () => prewarmScanner(), { once: false });
+  });
   $('scanClose').onclick = closeScanSheet;
   $('scanCancel').onclick = closeScanSheet;
   $('scanApply').onclick = applyScan;
 }
 
 async function runScan(file) {
-  $('scanProgress').textContent = 'Karte wird gelesen… 0%';
+  $('scanProgress').textContent = 'Texterkennung wird vorbereitet…';
   $('scanLoading').classList.add('show');
   try {
     const dataUrl = await readFile(file);
-    const result = await scanArbeitskarte(dataUrl, (p) => {
-      $('scanProgress').textContent = `Karte wird gelesen… ${Math.round(p * 100)}%`;
+    const result = await scanArbeitskarte(dataUrl, (u) => {
+      if (u && u.status === 'recognizing text') {
+        $('scanProgress').textContent = `Karte wird gelesen… ${Math.round((u.progress || 0) * 100)}%`;
+      } else {
+        $('scanProgress').textContent = 'Texterkennung wird geladen… (beim ersten Mal etwas länger)';
+      }
     });
     scanFields = result.fields || {};
     showScanSheet(scanFields, result.hits || 0);

--- a/js/app.js
+++ b/js/app.js
@@ -273,12 +273,15 @@ const SCAN_MAP = [
 let scanFields = {};
 
 function initScan() {
-  $('scanInput').addEventListener('change', async (e) => {
+  // Kamera UND Galerie: beide Eingänge lösen dieselbe Auto-Erkennung aus
+  const onScanFile = async (e) => {
     const file = (e.target.files || [])[0];
     e.target.value = '';
     if (!file) return;
     await runScan(file);
-  });
+  };
+  $('scanInput').addEventListener('change', onScanFile);
+  $('scanGalleryInput').addEventListener('change', onScanFile);
   $('scanClose').onclick = closeScanSheet;
   $('scanCancel').onclick = closeScanSheet;
   $('scanApply').onclick = applyScan;

--- a/js/scan.js
+++ b/js/scan.js
@@ -7,6 +7,9 @@ import { readZones } from './zones.js';
 
 const TESS_BASE = 'vendor/tesseract';
 let workerPromise = null;
+let progressCb = null; // aktueller Fortschritts-Empfänger (während eines Scans)
+
+function report(update) { try { progressCb && progressCb(update); } catch {} }
 
 // Tesseract wird erst bei Bedarf geladen (spart Start-Performance)
 function loadScript(src) {
@@ -18,7 +21,7 @@ function loadScript(src) {
   });
 }
 
-async function getWorker(onProgress) {
+function getWorker() {
   if (workerPromise) return workerPromise;
   workerPromise = (async () => {
     await loadScript(`${TESS_BASE}/tesseract.min.js`);
@@ -28,14 +31,17 @@ async function getWorker(onProgress) {
       corePath: `${TESS_BASE}/`,
       langPath: 'vendor/tessdata',
       gzip: true,
-      logger: (m) => {
-        if (onProgress && m.status === 'recognizing text') onProgress(m.progress);
-      },
+      // alle Phasen melden (Laden der Erkennung + eigentliches Lesen)
+      logger: (m) => report({ status: m.status, progress: m.progress || 0 }),
     });
     return worker;
   })().catch((e) => { workerPromise = null; throw e; });
   return workerPromise;
 }
+
+// Lädt die Texterkennung schon im Hintergrund (z.B. beim Antippen des
+// Scan-Knopfs, während der Nutzer das Foto auswählt) → erstes Scannen wirkt flott.
+export function prewarmScanner() { getWorker().catch(() => {}); }
 
 // Bild als HTMLCanvas in gewünschter Rotation (0/90/180/270 Grad)
 function rotated(img, deg) {
@@ -70,13 +76,22 @@ function downscale(img, maxEdge = 2600) {
 /**
  * Scannt eine Arbeitskarte.
  * @param {string} dataUrl  Bild als DataURL
- * @param {(p:number)=>void} onProgress  Fortschritt 0..1
+ * @param {(u:{status:string,progress:number})=>void} onProgress  Status/Fortschritt
  * @returns {Promise<{fields:object, confidence:number, text:string}>}
  */
 export async function scanArbeitskarte(dataUrl, onProgress) {
-  const worker = await getWorker(onProgress);
-  const img = await loadImage(dataUrl);
-  const base = downscale(img);
+  progressCb = onProgress;
+  try {
+    const worker = await getWorker();
+    const img = await loadImage(dataUrl);
+    const base = downscale(img);
+    return await runScanWith(worker, base);
+  } finally {
+    progressCb = null;
+  }
+}
+
+async function runScanWith(worker, base) {
 
   // Übliche Ausrichtungen testen (Foto kann gedreht sein). Aufrechtes
   // Hochformat (0°) zuerst, dann die gedrehten Varianten.

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-20';
+const CACHE = 'techdoku-v2026-21';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-19';
+const CACHE = 'techdoku-v2026-20';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier

--- a/tests/scan-ui.spec.js
+++ b/tests/scan-ui.spec.js
@@ -17,6 +17,7 @@ export async function scanArbeitskarte(_dataUrl, onProgress) {
     datumIso: '2026-05-27'
   }};
 }
+export function prewarmScanner() {}
 export async function disposeScanner() {}
 `;
 

--- a/tests/scan-ui.spec.js
+++ b/tests/scan-ui.spec.js
@@ -50,6 +50,15 @@ test('Scan-Übernahme füllt die erkannten Felder ins Formular', async ({ page }
   await expect(page.locator('#datum')).toHaveValue('2026-05-27');
 });
 
+test('Galerie-Eingang löst die Auto-Erkennung ebenfalls aus', async ({ page }) => {
+  await page.goto('/');
+  // Bild aus der Galerie (kein capture) statt Kamera
+  expect(await page.locator('#scanGalleryInput').getAttribute('capture')).toBeNull();
+  await page.setInputFiles('#scanGalleryInput', { name: 'gespeicherte_karte.jpg', mimeType: 'image/jpeg', buffer: PNG });
+  await expect(page.locator('#scanSheet')).toHaveClass(/open/);
+  await expect(page.locator('#scanResults .scan-row')).toHaveCount(8);
+});
+
 test('abgewählte Felder werden nicht übernommen', async ({ page }) => {
   await page.goto('/');
   await page.setInputFiles('#scanInput', { name: 'karte.jpg', mimeType: 'image/jpeg', buffer: PNG });


### PR DESCRIPTION
## 🖼️ Arbeitskarte auch aus der Galerie scannen

Bisher öffnete der Scan-Button zwingend die **Kamera** (`capture="environment"`), eine gespeicherte Karte aus der Galerie ließ sich nicht wählen.

### Jetzt zwei Wege – beide mit automatischer Erkennung
- **📷 Fotografieren** – Karte direkt mit der Kamera aufnehmen
- **🖼️ Aus Galerie** – ein gespeichertes Bild der Arbeitskarte auswählen

Beide lösen dieselbe automatische Felderkennung aus (inklusive deiner Scan-Vorlage/Zonen, falls eingerichtet).

### Technik
- Zweiter Datei-Eingang **ohne** `capture` für die Galerie, gemeinsamer Handler
- Buttons nebeneinander (auf sehr schmalen Geräten untereinander)
- Test: Galerie-Eingang öffnet den Übernahme-Dialog
- **60 Tests grün**, visuell verifiziert. SW-Cache erhöht.

https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S)_