### PR TITLE
↻ Scan-Vorlage: Karten-Bild um 90°/180° drehbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,7 @@
       <label for="zoneField">Feld:</label>
       <select id="zoneField"></select>
       <button class="zone-btn" id="zonePick" type="button">📷 Foto</button>
+      <button class="zone-btn" id="zoneRotate" type="button" title="Bild um 90° drehen">↻ Drehen</button>
       <button class="zone-btn" id="zoneClearAll" type="button">🗑 Alle</button>
     </div>
     <div class="zone-hint" id="zoneHint">Zuerst ein Foto einer Arbeitskarte wählen.</div>

--- a/js/zonecal.js
+++ b/js/zonecal.js
@@ -1,9 +1,10 @@
-// Scan-Vorlage einrichten: Foto einer Arbeitskarte laden, Kästchen über die
-// Felder ziehen und jeder Zone ein Feld zuordnen. Speichert relative Zonen.
+// Scan-Vorlage einrichten: Foto einer Arbeitskarte laden, bei Bedarf drehen,
+// Kästchen über die Felder ziehen und jeder Zone ein Feld zuordnen.
+// Speichert relative Zonen + das (gedrehte) Karten-Bild.
 import { Zones } from './store.js';
 import { ZONE_FIELDS, zoneLabel } from './zones.js';
 
-let canvas, ctx, baseImg, zones, resolveFn, hasImage;
+let canvas, ctx, baseImg, work, rot, zones, resolveFn, hasImage;
 
 function $(id) { return document.getElementById(id); }
 
@@ -11,7 +12,6 @@ function setup() {
   canvas = $('zoneCanvas');
   ctx = canvas.getContext('2d');
 
-  // Feld-Auswahl füllen
   const sel = $('zoneField');
   sel.innerHTML = ZONE_FIELDS.map((f) => `<option value="${f.key}">${f.label}</option>`).join('');
 
@@ -21,6 +21,7 @@ function setup() {
     e.target.value = '';
     if (f) loadPhoto(URL.createObjectURL(f));
   });
+  $('zoneRotate').onclick = rotate;
   $('zoneClearAll').onclick = () => { zones = []; renderList(); redraw(); };
   $('zoneCancel').onclick = () => close(false);
   $('zoneSave').onclick = save;
@@ -68,7 +69,6 @@ function bindPointer() {
   canvas.addEventListener('pointercancel', end);
 }
 
-// Nach dem Setzen automatisch zum nächsten noch freien Feld springen
 function autoAdvanceField() {
   const used = new Set(zones.map((z) => z.field));
   const next = ZONE_FIELDS.find((f) => !used.has(f.key));
@@ -83,7 +83,6 @@ function drawRect(a, b, field, preview) {
   ctx.fillStyle = 'rgba(56,189,248,.16)';
   ctx.fillRect(x, y, w, h);
   ctx.strokeRect(x, y, w, h);
-  // Beschriftung
   const fs = Math.max(12, canvas.width / 38);
   ctx.font = `700 ${fs}px system-ui, sans-serif`;
   const label = zoneLabel(field);
@@ -96,7 +95,7 @@ function drawRect(a, b, field, preview) {
 
 function redraw() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  if (hasImage) ctx.drawImage(baseImg, 0, 0, canvas.width, canvas.height);
+  if (hasImage && work) ctx.drawImage(work, 0, 0, canvas.width, canvas.height);
   zones.forEach((z) => drawRect(
     { x: z.x * canvas.width, y: z.y * canvas.height },
     { x: (z.x + z.w) * canvas.width, y: (z.y + z.h) * canvas.height },
@@ -120,24 +119,53 @@ function renderList() {
   });
 }
 
+// Erzeugt aus dem Originalbild ein auf die aktuelle Drehung gebrachtes Canvas
+function buildWork() {
+  const max = 1100;
+  let w = baseImg.naturalWidth || baseImg.width;
+  let h = baseImg.naturalHeight || baseImg.height;
+  const k = Math.max(w, h) > max ? max / Math.max(w, h) : 1;
+  w = Math.round(w * k); h = Math.round(h * k);
+  const c = document.createElement('canvas');
+  const c2 = c.getContext('2d');
+  if (rot === 90 || rot === 270) { c.width = h; c.height = w; } else { c.width = w; c.height = h; }
+  c2.save();
+  c2.translate(c.width / 2, c.height / 2);
+  c2.rotate(rot * Math.PI / 180);
+  c2.drawImage(baseImg, -w / 2, -h / 2, w, h);
+  c2.restore();
+  return c;
+}
+
+function applyWork() {
+  work = buildWork();
+  canvas.width = work.width; canvas.height = work.height;
+  hasImage = true;
+  redraw();
+}
+
+// Dreht Bild + vorhandene Kästchen um 90° im Uhrzeigersinn
+function rotate() {
+  if (!hasImage) return;
+  rot = (rot + 90) % 360;
+  zones = zones.map((z) => ({ field: z.field, x: 1 - z.y - z.h, y: z.x, w: z.h, h: z.w }));
+  applyWork();
+}
+
 function loadPhoto(src) {
   baseImg = new Image();
   baseImg.onload = () => {
-    const max = 1100; // kompakt halten (wird mitgespeichert)
-    let w = baseImg.width, h = baseImg.height;
-    if (Math.max(w, h) > max) { const k = max / Math.max(w, h); w = Math.round(w * k); h = Math.round(h * k); }
-    canvas.width = w; canvas.height = h;
-    hasImage = true;
-    $('zoneHint').textContent = 'Feld oben wählen und ein Kästchen über die passende Stelle ziehen.';
-    redraw();
+    rot = 0;
+    applyWork();
+    $('zoneHint').textContent = 'Bei Bedarf „↻ Drehen“, dann Feld wählen und ein Kästchen über die Stelle ziehen.';
   };
   baseImg.src = src;
 }
 
 function save() {
   if (!hasImage) { close(false); return; }
-  const aspect = canvas.width / canvas.height;
-  const image = canvas.toDataURL('image/jpeg', 0.7); // Karte als Vorschau/Bearbeitung
+  const aspect = work.width / work.height;
+  const image = work.toDataURL('image/jpeg', 0.7); // Karte OHNE eingezeichnete Kästchen
   Zones.save(zones, aspect, image);
   close(true);
 }
@@ -156,6 +184,7 @@ export function openZoneCalibrator() {
     resolveFn = resolve;
     zones = [];
     hasImage = false;
+    rot = 0;
 
     const tpl = Zones.get();
     const sel = $('zoneField'); if (sel) sel.value = ZONE_FIELDS[0].key;
@@ -167,12 +196,11 @@ export function openZoneCalibrator() {
 
     if (tpl && tpl.image) {
       zones = (tpl.items || []).map((z) => ({ ...z }));
-      $('zoneHint').textContent = 'Vorlage laden… Kästchen lassen sich anpassen oder neu ziehen.';
+      $('zoneHint').textContent = 'Vorlage laden… drehen oder Kästchen anpassen.';
       loadPhoto(tpl.image);
       renderList();
       open();
     } else {
-      // Noch keine Vorlage: leere Fläche, Nutzer wählt zuerst ein Foto
       canvas.width = 800; canvas.height = 1000;
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       $('zoneHint').textContent = 'Zuerst ein Foto einer Arbeitskarte wählen.';

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-21';
+const CACHE = 'techdoku-v2026-22';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier

--- a/tests/zones.spec.js
+++ b/tests/zones.spec.js
@@ -96,3 +96,21 @@ test('Scan-Vorlage: Kästchen ziehen, speichern und Status anzeigen', async ({ p
   await page.click('#zoneSetup');
   await expect(page.locator('.zone-item')).toHaveCount(1);
 });
+
+test('Scan-Vorlage: Bild lässt sich um 90° drehen (Hoch- ↔ Querformat)', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(2600);
+  await page.click('#zoneSetup');
+  await loadBigPhoto(page); // 600x800 → Hochformat
+
+  const before = await page.locator('#zoneCanvas').evaluate((c) => ({ w: c.width, h: c.height }));
+  expect(before.h).toBeGreaterThan(before.w); // Hochformat
+
+  await page.click('#zoneRotate');
+  const after = await page.locator('#zoneCanvas').evaluate((c) => ({ w: c.width, h: c.height }));
+  expect(after.w).toBeGreaterThan(after.h); // jetzt Querformat (gedreht)
+
+  await page.click('#zoneSave');
+  const tpl = await page.evaluate(() => JSON.parse(localStorage.getItem('techdoku_zones')));
+  expect(tpl.aspect).toBeGreaterThan(1); // gedrehtes (Quer-)Bild gespeichert
+});


### PR DESCRIPTION
## ↻ Karten-Bild drehbar (90° / 180°)

Beim Einrichten der **Scan-Vorlage** kann das geladene Karten-Bild jetzt gedreht werden — z. B. wenn ein Galerie-Foto quer oder kopfüber ist. So lässt sich die Arbeitskarte **korrekt ausrichten**, bevor die Felder-Kästchen gezogen werden.

### So funktioniert's
- Im Dialog „Scan-Vorlage" gibt es den Knopf **„↻ Drehen"** → dreht das Bild um **90°** pro Tipp (also 90° / 180° / 270°).
- Bereits gezeichnete **Kästchen drehen automatisch mit** (Koordinaten werden transformiert) – nichts verrutscht.

### Details
- Das gedrehte Bild wird als Vorlage gespeichert (passendes Hoch-/Querformat).
- Das Vorschaubild wird jetzt **ohne** die eingezeichneten Kästchen gesichert → sauberer beim erneuten Bearbeiten.
- Hinweis: Die eigentliche **Texterkennung** beim Scannen erkennt die Drehung ohnehin weiterhin **automatisch** (0/90/180/270) — die manuelle Drehung hilft v. a. beim sauberen Setzen der Zonen.

**62 Tests grün** (neuer Test: Hoch- ↔ Querformat per Drehen), visuell verifiziert. SW-Cache erhöht.

https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzX5qi9Hc5ZwNqSBfa68S)_