### PR TITLE
Live-Mitschrift: weniger verschluckte Wörter beim Neustart

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -654,3 +654,53 @@ footer.app-foot { text-align: center; color: var(--text-muted); font-size: 12px;
 
 .hidden { display: none !important; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+
+/* ===== Live-Mitschrift (Echtzeit-Transkription) ===== */
+.fab-rec {
+  position: fixed; right: 16px; bottom: calc(20px + var(--safe-bottom)); z-index: 90;
+  width: 60px; height: 60px; border-radius: 50%; border: none; cursor: pointer;
+  background: linear-gradient(135deg, var(--accent-strong), var(--accent));
+  color: #fff; font-size: 26px; box-shadow: var(--shadow-lg);
+  display: grid; place-items: center;
+}
+.fab-rec:active { transform: scale(.94); }
+
+.tr-body {
+  flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 14px;
+  padding: 16px; padding-bottom: calc(20px + var(--safe-bottom)); background: var(--bg);
+}
+.tr-status { display: flex; align-items: center; gap: 10px; color: var(--text); font-weight: 700; }
+.tr-dot { width: 12px; height: 12px; border-radius: 50%; background: var(--text-muted); flex: 0 0 auto; }
+.tr-dot.live { background: var(--danger); animation: pulse 1.2s infinite; }
+.tr-timer { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--text-muted); font-weight: 700; }
+.tr-note {
+  font-size: 12px; line-height: 1.5; color: var(--text-muted);
+  background: var(--surface-2); border: 1px solid var(--border);
+  border-left: 4px solid var(--accent); border-radius: var(--radius-sm); padding: 10px 12px;
+}
+.tr-transcript {
+  min-height: 160px; max-height: 42vh; overflow-y: auto;
+  background: var(--surface); border: 1.5px solid var(--border); border-radius: var(--radius-sm);
+  padding: 14px; font-size: 16px; line-height: 1.6; color: var(--text); white-space: pre-wrap;
+}
+.tr-placeholder { color: var(--text-muted); }
+.tr-interim { color: var(--accent); opacity: .8; }
+.btn.tr-rec { font-size: 17px; padding: 16px; }
+.btn.tr-rec.on { background: var(--danger); }
+.tr-tools { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.tr-saved-title { font-weight: 800; color: var(--text); margin-bottom: 8px; }
+.tr-empty { color: var(--text-muted); font-size: 14px; padding: 12px; background: var(--surface-2); border-radius: var(--radius-sm); }
+.tr-item { display: flex; align-items: stretch; gap: 8px; margin-bottom: 8px; }
+.tr-item-main {
+  flex: 1; text-align: left; background: var(--surface-2); border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm); padding: 10px 12px; cursor: pointer; color: var(--text);
+  display: flex; flex-direction: column; gap: 2px;
+}
+.tr-item-main strong { font-size: 14px; }
+.tr-item-main small { color: var(--text-muted); font-size: 12px; }
+.tr-item-main:hover { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.tr-item-btn {
+  flex: 0 0 auto; width: 44px; border: 1px solid var(--border); border-radius: var(--radius-sm);
+  background: var(--surface-2); cursor: pointer; font-size: 16px; color: var(--text-muted);
+}
+.tr-item-btn:hover { color: var(--accent); border-color: var(--accent); }

--- a/index.html
+++ b/index.html
@@ -276,6 +276,41 @@
     </section>
   </main>
 
+  <!-- Schwebe-Knopf: Live-Mitschrift starten (Echtzeit-Transkription) -->
+  <button class="fab-rec" id="fabRec" type="button" aria-label="Live-Mitschrift" title="Live-Mitschrift">🎙️</button>
+
+  <!-- Live-Mitschrift (Echtzeit-Transkription) -->
+  <div class="modal" id="trModal" role="dialog" aria-modal="true" aria-label="Live-Mitschrift">
+    <div class="modal-head">
+      <button id="trClose" type="button">✕ Schließen</button>
+      <h2>🎙️ Live-Mitschrift</h2>
+      <button id="trSave" type="button" style="background:#16a34a" disabled>💾 Speichern</button>
+    </div>
+    <div class="tr-body">
+      <div class="tr-status">
+        <span class="tr-dot" id="trDot" aria-hidden="true"></span>
+        <span id="trState">Bereit</span>
+        <span class="tr-timer" id="trTimer">00:00</span>
+      </div>
+      <div class="tr-note">Tipp: Bildschirm bleibt während der Aufnahme an. Echte Hintergrund-Aufnahme bei gesperrtem Handy ist im Browser nicht möglich – dafür braucht es ein Gerät wie Plaud.</div>
+      <div class="tr-transcript" id="trText" aria-live="polite" role="log">
+        <span class="tr-placeholder">Auf „Aufnahme starten“ tippen und sprechen – der Text erscheint hier live …</span>
+      </div>
+      <button class="btn btn-primary tr-rec" id="trToggle" type="button">⏺ Aufnahme starten</button>
+      <div class="tr-tools">
+        <button class="btn btn-ghost" id="trSummary" type="button" disabled>✨ Zusammenfassen</button>
+        <button class="btn btn-ghost" id="trToBemerkung" type="button" disabled>⬇️ In Bemerkung</button>
+        <button class="btn btn-ghost" id="trShare" type="button" disabled>📤 Teilen</button>
+        <button class="btn btn-ghost" id="trCopy" type="button" disabled>📋 Kopieren</button>
+        <button class="btn btn-ghost" id="trClear" type="button">🗑 Leeren</button>
+      </div>
+      <div class="tr-saved">
+        <div class="tr-saved-title">📁 Gespeicherte Mitschriften</div>
+        <div id="trList"></div>
+      </div>
+    </div>
+  </div>
+
   <!-- Foto-Editor -->
   <div class="modal" id="annoModal" role="dialog" aria-modal="true" aria-label="Foto markieren">
     <div class="modal-head">

--- a/js/app.js
+++ b/js/app.js
@@ -6,6 +6,7 @@ import { scanArbeitskarte, prewarmScanner } from './scan.js';
 import { openZoneCalibrator } from './zonecal.js';
 import { zoneLabel } from './zones.js';
 import { openSignaturePad } from './signature.js';
+import { initTranscribe } from './transcribe.js';
 
 const $ = (id) => document.getElementById(id);
 const MAX_IMAGES = 9;
@@ -41,6 +42,13 @@ function init() {
   initInstall();
   initZones();
   initSignature();
+  initTranscribe((text) => {
+    // Mitschrift in das Bemerkungsfeld übernehmen (an vorhandenen Text anhängen).
+    const ta = $('bemerkung');
+    ta.value = (ta.value ? ta.value.trim() + '\n\n' : '') + text;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+    saveDraft();
+  });
   refreshSuggestions();
   setToday();
   const last = Settings.get().lastVerantwortlich;

--- a/js/transcribe.js
+++ b/js/transcribe.js
@@ -106,11 +106,14 @@ function makeRec() {
     render();
   };
   r.onend = () => {
+    // Noch nicht "final" gewordenen Zwischenstand sichern, sonst gehen beim
+    // Neustart die zuletzt gesprochenen Wörter verloren.
+    if (interim.trim()) { finalText += (finalText ? ' ' : '') + interim.trim(); interim = ''; render(); }
     // Web Speech endet von selbst (Pausen/Limits). Solange der Nutzer noch
-    // aufnimmt: sofort neu starten -> läuft durch bis zum Stopp.
+    // aufnimmt: möglichst sofort neu starten -> läuft durch bis zum Stopp.
     if (wantOn) {
       clearTimeout(restartTimer);
-      restartTimer = setTimeout(() => { try { r.start(); } catch {} }, 250);
+      restartTimer = setTimeout(() => { try { r.start(); } catch {} }, 120);
     }
   };
   r.onerror = (e) => {

--- a/js/transcribe.js
+++ b/js/transcribe.js
@@ -1,0 +1,300 @@
+// Live-Mitschrift – Echtzeit-Transkription (wie "Plaud", aber als Web-App).
+// Sprache wird live in Text gewandelt (kein Audio wird gespeichert).
+//
+// WICHTIG / ehrliche Grenze: Eine PWA darf das Mikrofon NICHT im gesperrten
+// Bildschirm oder im Hintergrund weiterlaufen lassen – das unterbindet das
+// Handy-Betriebssystem (Datenschutz/Akku). Deshalb halten wir per Wake-Lock
+// den Bildschirm an, solange aufgenommen wird, und starten die Erkennung bei
+// Sprechpausen automatisch neu, sodass sie durchläuft, bis DU stoppst.
+
+const $ = (id) => document.getElementById(id);
+const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+
+// ---- Speicher: nur Text, daher genügt localStorage (klein & schnell) ----
+const KEY = 'techdoku_transcripts';
+const MAX = 30;
+const Notes = {
+  all() { try { return JSON.parse(localStorage.getItem(KEY)) || []; } catch { return []; } },
+  save(rec) {
+    const list = this.all().filter((n) => n.id !== rec.id);
+    list.unshift(rec);
+    try { localStorage.setItem(KEY, JSON.stringify(list.slice(0, MAX))); } catch {}
+  },
+  remove(id) {
+    try { localStorage.setItem(KEY, JSON.stringify(this.all().filter((n) => n.id !== id))); } catch {}
+  },
+};
+
+// ---- Laufzeit-Zustand ----
+let rec = null;        // SpeechRecognition-Instanz
+let wantOn = false;    // Nutzer möchte aufnehmen (steuert Auto-Neustart)
+let finalText = '';    // gesicherter (fertig erkannter) Text
+let interim = '';      // aktuell noch in Erkennung
+let startedAt = 0;     // Zeitstempel Aufnahmebeginn
+let elapsedBase = 0;   // bereits gelaufene ms (bei Pause/Fortsetzen)
+let timerId = null;
+let wakeLock = null;
+let restartTimer = null;
+let currentId = null;  // geladene/zu überschreibende Mitschrift
+
+function fmtTime(ms) {
+  const s = Math.floor(ms / 1000);
+  const m = Math.floor(s / 60);
+  return `${String(m).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`;
+}
+function fmtDate(ts) {
+  try { return new Date(ts).toLocaleString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' }); }
+  catch { return ''; }
+}
+function esc(s) { return String(s || '').replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
+
+// ---- Bildschirm wachhalten, damit er sich nicht sperrt (Mic bliebe sonst stehen) ----
+async function acquireWake() {
+  try { if ('wakeLock' in navigator && !wakeLock) wakeLock = await navigator.wakeLock.request('screen'); } catch {}
+}
+function releaseWake() { try { wakeLock && wakeLock.release(); } catch {} wakeLock = null; }
+
+// ---- Anzeige ----
+function render() {
+  const box = $('trText');
+  if (!box) return;
+  if (!finalText && !interim) {
+    box.innerHTML = '<span class="tr-placeholder">Auf „Aufnahme starten“ tippen und sprechen – der Text erscheint hier live …</span>';
+  } else {
+    box.innerHTML = esc(finalText) + (interim ? `<span class="tr-interim"> ${esc(interim)}</span>` : '');
+    box.scrollTop = box.scrollHeight;
+  }
+  $('trToBemerkung').disabled = !finalText.trim();
+  $('trSummary').disabled = !finalText.trim();
+  $('trShare').disabled = !finalText.trim();
+  $('trCopy').disabled = !finalText.trim();
+  $('trSave').disabled = !finalText.trim();
+}
+
+function setState(on) {
+  const dot = $('trDot'), state = $('trState'), toggle = $('trToggle');
+  dot.classList.toggle('live', on);
+  state.textContent = on ? 'Nimmt auf …' : (finalText ? 'Pausiert' : 'Bereit');
+  toggle.classList.toggle('on', on);
+  toggle.innerHTML = on ? '⏹ Aufnahme stoppen' : '⏺ Aufnahme starten';
+}
+
+function tickTimer() {
+  const el = $('trTimer');
+  if (el) el.textContent = fmtTime(elapsedBase + (startedAt ? Date.now() - startedAt : 0));
+}
+
+// ---- Erkennungs-Engine ----
+function makeRec() {
+  const r = new SR();
+  r.lang = 'de-DE';
+  r.continuous = true;
+  r.interimResults = true;
+  r.onresult = (e) => {
+    let live = '';
+    for (let i = e.resultIndex; i < e.results.length; i++) {
+      const res = e.results[i];
+      const txt = res[0].transcript;
+      if (res.isFinal) {
+        const t = txt.trim();
+        if (t) finalText += (finalText ? ' ' : '') + t;
+      } else {
+        live += txt;
+      }
+    }
+    interim = live;
+    render();
+  };
+  r.onend = () => {
+    // Web Speech endet von selbst (Pausen/Limits). Solange der Nutzer noch
+    // aufnimmt: sofort neu starten -> läuft durch bis zum Stopp.
+    if (wantOn) {
+      clearTimeout(restartTimer);
+      restartTimer = setTimeout(() => { try { r.start(); } catch {} }, 250);
+    }
+  };
+  r.onerror = (e) => {
+    if (e.error === 'not-allowed' || e.error === 'service-not-allowed') {
+      wantOn = false;
+      stop();
+      toastTr('Mikrofon ist blockiert – bitte den Zugriff erlauben.');
+    }
+    // 'no-speech' / 'aborted' / 'network' ignorieren – onend startet neu.
+  };
+  return r;
+}
+
+function start() {
+  if (!SR) { toastTr('Spracherkennung wird von diesem Browser nicht unterstützt.'); return; }
+  if (wantOn) return;
+  wantOn = true;
+  rec = makeRec();
+  try { rec.start(); } catch {}
+  startedAt = Date.now();
+  clearInterval(timerId);
+  timerId = setInterval(tickTimer, 500);
+  acquireWake();
+  setState(true);
+}
+
+function stop() {
+  wantOn = false;
+  clearTimeout(restartTimer);
+  if (rec) { try { rec.stop(); } catch {} }
+  rec = null;
+  if (startedAt) { elapsedBase += Date.now() - startedAt; startedAt = 0; }
+  clearInterval(timerId);
+  interim = '';
+  releaseWake();
+  setState(false);
+  render();
+}
+
+function resetSession() {
+  stop();
+  finalText = ''; interim = ''; elapsedBase = 0; currentId = null;
+  render(); tickTimer();
+}
+
+// ---- Lokale Kurzfassung (extraktiv, ganz ohne Internet) ----
+const STOP = new Set(('der die das und oder aber ich du er sie es wir ihr ein eine einen einem einer ' +
+  'ist sind war waren hat haben hatte mit von zu im in den dem des auf für als auch so dann noch nur ' +
+  'wie was wenn weil dass ja nein mal halt eben also schon mir mich dir dich uns euch sich am an bei ' +
+  'aus nach vor über unter durch um doch wird werden kann können muss müssen soll sollen das').split(/\s+/));
+
+function summarize(text) {
+  const sentences = text.replace(/\s+/g, ' ').match(/[^.!?]+[.!?]?/g) || [];
+  const clean = sentences.map((s) => s.trim()).filter((s) => s.split(' ').length >= 4);
+  if (clean.length <= 3) return clean;
+  const freq = {};
+  text.toLowerCase().match(/[a-zäöüß]{4,}/g)?.forEach((w) => { if (!STOP.has(w)) freq[w] = (freq[w] || 0) + 1; });
+  const scored = clean.map((s, i) => {
+    let score = 0;
+    s.toLowerCase().match(/[a-zäöüß]{4,}/g)?.forEach((w) => { if (freq[w]) score += freq[w]; });
+    return { s, i, score: score / Math.sqrt(s.split(' ').length) };
+  });
+  const keep = Math.min(5, Math.max(3, Math.round(clean.length * 0.25)));
+  return scored.sort((a, b) => b.score - a.score).slice(0, keep)
+    .sort((a, b) => a.i - b.i).map((o) => o.s);
+}
+
+// ---- Speichern / Liste ----
+function fullText() { return finalText.trim(); }
+
+function saveCurrent() {
+  const text = fullText();
+  if (!text) return;
+  const id = currentId || ('tr_' + Date.now());
+  const title = text.split(/\s+/).slice(0, 7).join(' ') + (text.split(/\s+/).length > 7 ? ' …' : '');
+  Notes.save({ id, title, text, createdAt: Date.now(), durationMs: elapsedBase });
+  currentId = id;
+  renderList();
+  toastTr('Mitschrift gespeichert.');
+}
+
+function renderList() {
+  const wrap = $('trList');
+  const list = Notes.all();
+  if (!list.length) { wrap.innerHTML = '<div class="tr-empty">Noch keine gespeicherten Mitschriften.</div>'; return; }
+  wrap.innerHTML = list.map((n) => `
+    <div class="tr-item" data-id="${n.id}">
+      <button class="tr-item-main" data-act="load" data-id="${n.id}">
+        <strong>${esc(n.title || 'Mitschrift')}</strong>
+        <small>${fmtDate(n.createdAt)} · ${fmtTime(n.durationMs || 0)}</small>
+      </button>
+      <button class="tr-item-btn" data-act="share" data-id="${n.id}" title="Teilen" aria-label="Teilen">📤</button>
+      <button class="tr-item-btn" data-act="del" data-id="${n.id}" title="Löschen" aria-label="Löschen">🗑</button>
+    </div>`).join('');
+}
+
+function loadNote(id) {
+  const n = Notes.all().find((x) => x.id === id);
+  if (!n) return;
+  resetSession();
+  finalText = n.text; currentId = n.id; elapsedBase = n.durationMs || 0;
+  render(); tickTimer();
+  toastTr('Mitschrift geladen.');
+}
+
+// ---- Teilen / Kopieren ----
+async function shareText(text) {
+  if (!text) return;
+  if (navigator.share) { try { await navigator.share({ title: 'Mitschrift', text }); return; } catch {} }
+  copyText(text);
+}
+async function copyText(text) {
+  try { await navigator.clipboard.writeText(text); toastTr('In die Zwischenablage kopiert.'); }
+  catch { toastTr('Kopieren nicht möglich.'); }
+}
+
+// kleiner eigener Toast (in App.toast nicht direkt erreichbar)
+let trToastTimer;
+function toastTr(msg) {
+  const t = $('toast');
+  if (!t) return;
+  t.className = 'toast show'; t.textContent = msg; t.onclick = null;
+  clearTimeout(trToastTimer);
+  trToastTimer = setTimeout(() => t.classList.remove('show'), 2400);
+}
+
+function open() {
+  $('trModal').classList.add('open');
+  renderList();
+  render();
+}
+function close() {
+  if (wantOn && !confirm('Aufnahme läuft noch. Mitschrift schließen? (Text bleibt erhalten, bis du leerst.)')) return;
+  stop();
+  $('trModal').classList.remove('open');
+}
+
+export function initTranscribe(onToBemerkung) {
+  const fab = $('fabRec');
+  if (!fab) return;
+  if (!SR) {
+    // Ohne Spracherkennung hat die Funktion keinen Sinn -> Knopf ausblenden.
+    fab.style.display = 'none';
+    return;
+  }
+  fab.onclick = open;
+  $('trClose').onclick = close;
+  $('trToggle').onclick = () => (wantOn ? stop() : start());
+  $('trSave').onclick = saveCurrent;
+  $('trClear').onclick = () => { if (!fullText() || confirm('Aktuelle Mitschrift leeren?')) resetSession(); };
+  $('trCopy').onclick = () => copyText(fullText());
+  $('trShare').onclick = () => shareText(fullText());
+  $('trSummary').onclick = () => {
+    const pts = summarize(fullText());
+    if (!pts.length) { toastTr('Zu wenig Text für eine Kurzfassung.'); return; }
+    finalText = '📋 Kurzfassung:\n• ' + pts.join('\n• ') + '\n\n— — —\n\n' + fullText();
+    render();
+    toastTr('Kurzfassung oben eingefügt.');
+  };
+  $('trToBemerkung').onclick = () => {
+    const text = fullText();
+    if (!text) return;
+    if (typeof onToBemerkung === 'function') onToBemerkung(text);
+    close();
+    toastTr('In das Bemerkungsfeld übernommen.');
+  };
+
+  // Liste: Laden / Teilen / Löschen
+  $('trList').addEventListener('click', (e) => {
+    const b = e.target.closest('[data-act]');
+    if (!b) return;
+    const id = b.dataset.id;
+    if (b.dataset.act === 'load') loadNote(id);
+    else if (b.dataset.act === 'share') { const n = Notes.all().find((x) => x.id === id); if (n) shareText(n.text); }
+    else if (b.dataset.act === 'del') { if (confirm('Diese Mitschrift löschen?')) { Notes.remove(id); renderList(); } }
+  });
+
+  // Kommt der Bildschirm zurück, Wake-Lock erneut anfordern (Browser gibt ihn frei).
+  document.addEventListener('visibilitychange', () => {
+    if (wantOn && document.visibilityState === 'visible') acquireWake();
+  });
+
+  // Über Startbildschirm-Shortcut direkt öffnen (?record=1)
+  try { if (new URLSearchParams(location.search).get('record') === '1') open(); } catch {}
+
+  render();
+}

--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,12 @@
       "short_name": "Neu",
       "description": "Leeres Formular öffnen",
       "url": "./index.html?new=1"
+    },
+    {
+      "name": "Live-Mitschrift",
+      "short_name": "Mitschrift",
+      "description": "Echtzeit-Transkription starten",
+      "url": "./index.html?record=1"
     }
   ],
   "prefer_related_applications": false

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-23';
+const CACHE = 'techdoku-v2026-24';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-22';
+const CACHE = 'techdoku-v2026-23';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier
@@ -19,6 +19,7 @@ const ASSETS = [
   './js/zonecal.js',
   './js/archive.js',
   './js/signature.js',
+  './js/transcribe.js',
   './vendor/jspdf.umd.min.js',
   './manifest.json',
   './icon-192.png',

--- a/tests/transcribe.spec.js
+++ b/tests/transcribe.spec.js
@@ -1,0 +1,67 @@
+const { test, expect } = require('@playwright/test');
+
+// Die Live-Mitschrift nutzt die Web Speech API, die es im Headless-Chromium
+// nicht gibt. Wir spielen vor dem Laden eine schlanke Fake-Erkennung ein,
+// damit wir die Oberfläche und den Ablauf testen können.
+async function injectFakeSpeech(page) {
+  await page.addInitScript(() => {
+    class FakeSR {
+      constructor() { this.lang = ''; this.continuous = false; this.interimResults = false; window.__lastSR = this; }
+      start() { this._on = true; if (this.onstart) this.onstart(); }
+      stop() { this._on = false; if (this.onend) this.onend(); }
+      abort() { this.stop(); }
+    }
+    window.SpeechRecognition = FakeSR;
+  });
+}
+
+async function fireFinal(page, text) {
+  await page.evaluate((t) => {
+    const r = window.__lastSR;
+    const item = Object.assign([{ transcript: t }], { isFinal: true });
+    r.onresult({ resultIndex: 0, results: Object.assign([item], { length: 1 }) });
+  }, text);
+}
+
+test('Live-Mitschrift: Knopf, Aufnahme, Live-Text und Speichern', async ({ page }) => {
+  await injectFakeSpeech(page);
+  await page.goto('/');
+
+  // Schwebe-Knopf ist da (Spracherkennung vorhanden) und öffnet das Fenster
+  await expect(page.locator('#fabRec')).toBeVisible();
+  await page.click('#fabRec');
+  await expect(page.locator('#trModal')).toBeVisible();
+
+  // Aufnahme starten -> Status wechselt
+  await page.click('#trToggle');
+  await expect(page.locator('#trState')).toHaveText('Nimmt auf …');
+  await expect(page.locator('#trDot')).toHaveClass(/live/);
+
+  // Erkanntes Wort erscheint live
+  await fireFinal(page, 'Reklamation an Maschine fünf');
+  await expect(page.locator('#trText')).toContainText('Reklamation an Maschine fünf');
+
+  // Stoppen
+  await page.click('#trToggle');
+  await expect(page.locator('#trState')).toHaveText('Pausiert');
+
+  // Speichern legt einen Eintrag in der Liste an
+  await page.click('#trSave');
+  await expect(page.locator('#trList .tr-item')).toHaveCount(1);
+
+  // In Bemerkung übernehmen schreibt den Text ins Formular
+  await page.click('#trToBemerkung');
+  await expect(page.locator('#trModal')).toBeHidden();
+  await expect(page.locator('#bemerkung')).toHaveValue(/Reklamation an Maschine fünf/);
+});
+
+test('Live-Mitschrift: ohne Spracherkennung bleibt der Knopf verborgen', async ({ page }) => {
+  await page.addInitScript(() => {
+    try { delete window.SpeechRecognition; } catch {}
+    try { delete window.webkitSpeechRecognition; } catch {}
+    Object.defineProperty(window, 'SpeechRecognition', { value: undefined, configurable: true });
+    Object.defineProperty(window, 'webkitSpeechRecognition', { value: undefined, configurable: true });
+  });
+  await page.goto('/');
+  await expect(page.locator('#fabRec')).toBeHidden();
+});


### PR DESCRIPTION
## Problem
Die Erkennung verschluckte Wörter, besonders nach Sprechpausen.

## Ursache & Fix
- Beim automatischen Neustart der Erkennung (nach Pausen/Limits) ging der noch nicht „final" gewordene Zwischenstand verloren → abgehackte Sätze. Jetzt wird er gesichert.
- Neustart-Lücke von 250 ms auf 120 ms verkürzt → weniger Audio fällt weg.
- Service-Worker-Version erhöht, damit das Update automatisch ankommt.

> Hinweis: Das ist eine Verbesserung, kein Allheilmittel. Die grundsätzliche Genauigkeit ist durch die Browser-Spracherkennung (Web Speech API) begrenzt — anders als Plaud, das ein Cloud-KI-Modell (Whisper-Klasse) nutzt.

Tests: alle Transkriptions-E2E-Tests grün.

https://claude.ai/code/session_01ShVpvnvAWB2rxihP9tW1WR

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShVpvnvAWB2rxihP9tW1WR)_