### PR TITLE
Live-Mitschrift: weniger verschluckte Wörter beim Neustart

### DIFF
--- a/js/transcribe.js
+++ b/js/transcribe.js
@@ -106,11 +106,14 @@ function makeRec() {
     render();
   };
   r.onend = () => {
+    // Noch nicht "final" gewordenen Zwischenstand sichern, sonst gehen beim
+    // Neustart die zuletzt gesprochenen Wörter verloren.
+    if (interim.trim()) { finalText += (finalText ? ' ' : '') + interim.trim(); interim = ''; render(); }
     // Web Speech endet von selbst (Pausen/Limits). Solange der Nutzer noch
-    // aufnimmt: sofort neu starten -> läuft durch bis zum Stopp.
+    // aufnimmt: möglichst sofort neu starten -> läuft durch bis zum Stopp.
     if (wantOn) {
       clearTimeout(restartTimer);
-      restartTimer = setTimeout(() => { try { r.start(); } catch {} }, 250);
+      restartTimer = setTimeout(() => { try { r.start(); } catch {} }, 120);
     }
   };
   r.onerror = (e) => {

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-23';
+const CACHE = 'techdoku-v2026-24';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier


### PR DESCRIPTION
## Problem
Die Erkennung verschluckte Wörter, besonders nach Sprechpausen.

## Ursache & Fix
- Beim automatischen Neustart der Erkennung ging der noch nicht „final" gewordene Zwischenstand verloren → abgehackte Sätze. Jetzt wird er gesichert.
- Neustart-Lücke von 250 ms auf 120 ms verkürzt → weniger Audio fällt weg.
- Service-Worker-Version erhöht, damit das Update automatisch ankommt.

> Hinweis: Verbesserung, kein Allheilmittel. Die Grundgenauigkeit ist durch die Browser-Spracherkennung (Web Speech API) begrenzt — anders als Plaud (Cloud-KI / Whisper-Klasse).

Ersetzt #26 (war wegen Branch-Historie in Konflikt).

https://claude.ai/code/session_01ShVpvnvAWB2rxihP9tW1WR

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShVpvnvAWB2rxihP9tW1WR)_