### PR TITLE
Schnell-Modus: kumulative Wort-Doppelung beheben

### DIFF
--- a/js/transcribe.js
+++ b/js/transcribe.js
@@ -116,7 +116,7 @@ function makeRec() {
       const txt = res[0].transcript;
       if (res.isFinal) {
         const t = txt.trim();
-        if (t) finalText += (finalText ? ' ' : '') + t;
+        if (t) finalText = collapseRepeats((finalText ? finalText + ' ' : '') + t);
       } else {
         live += txt;
       }
@@ -125,14 +125,17 @@ function makeRec() {
     render();
   };
   r.onend = () => {
-    // Noch nicht "final" gewordenen Zwischenstand sichern, sonst gehen beim
-    // Neustart die zuletzt gesprochenen Wörter verloren.
-    if (interim.trim()) { finalText += (finalText ? ' ' : '') + interim.trim(); interim = ''; render(); }
-    // Web Speech endet von selbst (Pausen/Limits). Solange der Nutzer noch
-    // aufnimmt: möglichst sofort neu starten -> läuft durch bis zum Stopp.
     if (wantOn) {
+      // Auto-Neustart bei Sprechpausen: den Zwischenstand NICHT übernehmen –
+      // sonst doppeln sich Wörter ("Red Bull Red Bull und dann ...").
+      // Pausen-Wörter sind in aller Regel schon als "final" angekommen.
       clearTimeout(restartTimer);
       restartTimer = setTimeout(() => { try { r.start(); } catch {} }, 120);
+    } else if (interim.trim()) {
+      // Nur beim echten Stopp: letzten Zwischenstand noch sichern.
+      finalText = collapseRepeats((finalText ? finalText + ' ' : '') + interim.trim());
+      interim = '';
+      render();
     }
   };
   r.onerror = (e) => {

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-27';
+const CACHE = 'techdoku-v2026-28';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier

--- a/tests/transcribe.spec.js
+++ b/tests/transcribe.spec.js
@@ -69,6 +69,17 @@ test('Live-Mitschrift: ohne Browser-Spracherkennung übernimmt der KI-Modus', as
   await expect(page.locator('#trModeAi')).toBeChecked();
 });
 
+test('Live-Mitschrift: Wortwiederholungen werden zusammengefasst', async ({ page }) => {
+  await injectFakeSpeech(page);
+  await page.goto('/');
+  await page.click('#fabRec');
+  await page.click('#trToggle');
+  await fireFinal(page, 'Red Bull Red Bull Red Bull und dann gehen wir');
+  await expect(page.locator('#trText')).toContainText('Red Bull und dann gehen wir');
+  const txt = await page.locator('#trText').innerText();
+  expect((txt.match(/Red Bull/g) || []).length).toBe(1); // nur einmal, nicht gedoppelt
+});
+
 test('Live-Mitschrift: Modus-Umschalter ist vorhanden und Schnell ist Standard', async ({ page }) => {
   await injectFakeSpeech(page);
   await page.goto('/');


### PR DESCRIPTION
## Problem
Im Schnell-Modus doppelten sich Wörter kumulativ:
> „gleich Red Bull Red Bull Red Bull und Red Bull und dann Red Bull und dann gehen Red Bull und dann gehen wir"

## Ursache
Ein früherer Genauigkeits-Fix sicherte den Zwischenstand der Erkennung bei **jedem** automatischen Neustart (an Sprechpausen). Da der Halbsatz beim Sprechen wächst, wurde er bei jedem Neustart erneut angehängt → „Red Bull / Red Bull und / Red Bull und dann …".

## Fix
- Zwischenstand wird **nur beim echten Stopp** übernommen, nicht bei den Neustarts an Sprechpausen (die Pausen-Wörter kommen ohnehin als „final" an).
- `collapseRepeats()` wird jetzt auch im Schnell-Modus auf jeden Final-Schnipsel angewandt (Sicherheitsnetz gegen Doppelungen).
- Neuer E2E-Test: `Red Bull Red Bull Red Bull und dann gehen wir` → „Red Bull" kommt nur **einmal** vor.

## Tests
Alle 8 Transkriptions-Tests grün (verifiziert: schrittweises Anhängen und Roh-String ergeben beide „Red Bull und dann gehen wir").

https://claude.ai/code/session_01ShVpvnvAWB2rxihP9tW1WR

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShVpvnvAWB2rxihP9tW1WR)_