### PR TITLE
Schnell-Modus: Doppelungen endgültig beheben (Text neu aufbauen) + Hosokawa

### DIFF
--- a/js/transcribe.js
+++ b/js/transcribe.js
@@ -38,6 +38,12 @@ let timerId = null;
 let wakeLock = null;
 let restartTimer = null;
 let currentId = null;  // geladene/zu überschreibende Mitschrift
+// Schnell-Modus: festgeschriebener Text aus beendeten Erkennungs-Sitzungen +
+// das, was die LAUFENDE Sitzung gerade als "final" liefert. Wir bauen den Text
+// bei jedem Update KOMPLETT neu auf (committed + sessionFinal), statt anzuhängen.
+// So kann sich nichts doppeln, auch wenn der Browser die Ergebnisliste neu sendet.
+let committed = '';
+let sessionFinal = '';
 
 // Erkennungs-Modus: 'fast' = Browser-Spracherkennung (live, online),
 // 'ai' = Whisper-KI komplett auf dem Gerät (genauer, privat, etwas verzögert).
@@ -118,32 +124,29 @@ function makeRec() {
   r.continuous = true;
   r.interimResults = true;
   r.onresult = (e) => {
-    let live = '';
-    for (let i = e.resultIndex; i < e.results.length; i++) {
+    // Text der LAUFENDEN Sitzung jedes Mal komplett aus der Ergebnisliste
+    // neu zusammensetzen (nicht anhängen!) – verhindert Doppelungen, falls der
+    // Browser bei jedem Event die ganze Liste erneut schickt.
+    let fin = '', live = '';
+    for (let i = 0; i < e.results.length; i++) {
       const res = e.results[i];
-      const txt = res[0].transcript;
-      if (res.isFinal) {
-        const t = applyGlossary(txt.trim());
-        if (t) finalText = collapseRepeats((finalText ? finalText + ' ' : '') + t);
-      } else {
-        live += txt;
-      }
+      const txt = (res[0] && res[0].transcript) || '';
+      if (res.isFinal) fin += txt + ' '; else live += txt + ' ';
     }
-    interim = live;
+    sessionFinal = fin.trim();
+    interim = live.trim();
+    finalText = clean((committed ? committed + ' ' : '') + sessionFinal);
     render();
   };
   r.onend = () => {
+    // Sitzung festschreiben (nur den finalen Teil; Zwischenstand kommt beim
+    // Stopp über stopFast). Dann ggf. neu starten.
+    committed = clean((committed ? committed + ' ' : '') + sessionFinal);
+    sessionFinal = '';
+    finalText = committed; render();
     if (wantOn) {
-      // Auto-Neustart bei Sprechpausen: den Zwischenstand NICHT übernehmen –
-      // sonst doppeln sich Wörter ("Red Bull Red Bull und dann ...").
-      // Pausen-Wörter sind in aller Regel schon als "final" angekommen.
       clearTimeout(restartTimer);
       restartTimer = setTimeout(() => { try { r.start(); } catch {} }, 120);
-    } else if (interim.trim()) {
-      // Nur beim echten Stopp: letzten Zwischenstand noch sichern.
-      finalText = collapseRepeats((finalText ? finalText + ' ' : '') + applyGlossary(interim.trim()));
-      interim = '';
-      render();
     }
   };
   r.onerror = (e) => {
@@ -166,11 +169,16 @@ function setAiStatus(msg) {
 function start() { return mode === 'ai' ? startAi() : startFast(); }
 function stop() { return mode === 'ai' ? stopAi() : stopFast(); }
 
+// Text aufräumen: Fachbegriffe angleichen + Wiederholungs-Schleifen kollabieren.
+function clean(s) { return collapseRepeats(applyGlossary(applyAliases((s || '').trim()))); }
+
 /* ---------- Modus „Schnell" (Browser-Spracherkennung) ---------- */
 function startFast() {
   if (!SR) { toastTr('Spracherkennung wird von diesem Browser nicht unterstützt.'); return; }
   if (wantOn) return;
   wantOn = true;
+  committed = finalText.trim(); // an vorhandenen Text (geladene Notiz) anknüpfen
+  sessionFinal = ''; interim = '';
   rec = makeRec();
   try { rec.start(); } catch {}
   startedAt = Date.now();
@@ -185,9 +193,12 @@ function stopFast() {
   clearTimeout(restartTimer);
   if (rec) { try { rec.stop(); } catch {} }
   rec = null;
+  // Restlichen finalen Text + letzten Zwischenstand festschreiben.
+  committed = clean((committed ? committed + ' ' : '') + sessionFinal + (interim ? ' ' + interim : ''));
+  sessionFinal = ''; interim = '';
+  finalText = committed;
   if (startedAt) { elapsedBase += Date.now() - startedAt; startedAt = 0; }
   clearInterval(timerId);
-  interim = '';
   releaseWake();
   setState(false);
   render();
@@ -245,7 +256,7 @@ function collapseRepeats(text) {
   const out = [];
   for (const t of tok) {
     out.push(t);
-    for (let k = 1; k <= 5; k++) {
+    for (let k = 1; k <= 8; k++) {
       if (out.length >= 2 * k) {
         let rep = true;
         for (let i = 0; i < k; i++) {
@@ -284,8 +295,7 @@ async function transcribeBlob(blob) {
       temperature: 0,                     // deterministisch (kein „Fantasieren")
       compression_ratio_threshold: 2.4,   // verdächtig repetitive Ausgaben verwerfen
     });
-    let t = applyGlossary(collapseRepeats(((res && res.text) || '').trim()));
-    t = trimBoundary(t);
+    let t = trimBoundary(clean(((res && res.text) || '').trim()));
     if (t) { finalText += (finalText ? ' ' : '') + t; render(); }
   } catch {
     // Einzelnes Segment fehlgeschlagen – weiterlaufen, nicht alles abbrechen.
@@ -369,7 +379,7 @@ function stopAi() {
 
 function resetSession() {
   stop();
-  finalText = ''; interim = ''; elapsedBase = 0; currentId = null;
+  finalText = ''; interim = ''; committed = ''; sessionFinal = ''; elapsedBase = 0; currentId = null;
   render(); tickTimer();
 }
 
@@ -381,9 +391,23 @@ const DOMAIN_TERMS = (
   'Spanndruck Position Maschine Toleranz Maßabweichung Oberfläche Rauheit Gewinde Bohrung Durchmesser ' +
   'Radius Fase Passung Planfläche Fräsen Drehen Schleifen Bohren Werkstück Werkzeug Vorrichtung Spannmittel ' +
   'Messprotokoll Nacharbeit Ausschuss Charge Rüsten Bauteil Baugruppe Schweißnaht Härtung Beschichtung ' +
-  'Grat entgraten Riss Lunker Pore Verzug Maßhaltigkeit Konturf Welle Lager Flansch Nut Bund Senkung ' +
-  'Verantwortlich Liefertermin Auftrag Mangel Abnahme Prüfung Kontur Mittelpunkt Anschlag'
+  'Grat entgraten Riss Lunker Pore Verzug Maßhaltigkeit Welle Lager Flansch Nut Bund Senkung ' +
+  'Verantwortlich Liefertermin Auftrag Mangel Abnahme Prüfung Kontur Mittelpunkt Anschlag ' +
+  'Hosokawa'
 ).split(/\s+/);
+
+// Feste Korrekturen für oft falsch gehörte (mehrwortige) Eigennamen/Begriffe.
+// Hier kannst du jederzeit weitere Begriffe ergänzen lassen.
+const ALIASES = [
+  [/\bhose\s+cover\b/gi, 'Hosokawa'],
+  [/\bhoso\s*kawa\b/gi, 'Hosokawa'],
+  [/\bhosokava\b/gi, 'Hosokawa'],
+];
+function applyAliases(text) {
+  let t = text || '';
+  for (const [re, to] of ALIASES) t = t.replace(re, to);
+  return t;
+}
 
 let glossary = []; // [{ words:[lc...], n, term }] – längste zuerst
 function buildGlossary() {

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-30';
+const CACHE = 'techdoku-v2026-31';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier

--- a/tests/transcribe.spec.js
+++ b/tests/transcribe.spec.js
@@ -80,6 +80,20 @@ test('Live-Mitschrift: Wortwiederholungen werden zusammengefasst', async ({ page
   expect((txt.match(/Red Bull/g) || []).length).toBe(1); // nur einmal, nicht gedoppelt
 });
 
+test('Live-Mitschrift: erneut gesendete Ergebnisse doppeln nicht (+ Alias)', async ({ page }) => {
+  await injectFakeSpeech(page);
+  await page.goto('/');
+  await page.click('#fabRec');
+  await page.click('#trToggle');
+  // Manche Browser senden bei jedem Event die ganze Liste neu – darf nicht doppeln.
+  await fireFinal(page, 'Hose Cover liefert die Maschine');
+  await fireFinal(page, 'Hose Cover liefert die Maschine');
+  const txt = await page.locator('#trText').innerText();
+  expect(txt).toContain('Hosokawa');                       // Alias greift
+  expect((txt.match(/Hosokawa/g) || []).length).toBe(1);   // nur einmal
+  expect((txt.match(/Maschine/g) || []).length).toBe(1);
+});
+
 test('Live-Mitschrift: Fachbegriffe werden korrigiert', async ({ page }) => {
   await injectFakeSpeech(page);
   await page.goto('/');


### PR DESCRIPTION
## Problem
Im Schnell-Modus wiederholte sich Text weiterhin und wuchs auf:
> „… das gesprochen wird wenn da wegen Kundschaft das gesprochen wird … Hose Cover und so"

Zusätzlich: „Hosokawa" wurde als „Hose Cover" erkannt.

## Ursache
Manche Browser (v. a. Android) senden bei **jedem** `onresult`-Event die **komplette** Ergebnisliste erneut. Der Code hängte aber jedes Mal an → der Satz wuchs und doppelte sich.

## Fix
- **Text wird pro Update komplett neu aufgebaut** (`committed` aus beendeten Sitzungen + `sessionFinal` der laufenden Sitzung) statt angehängt → strukturell keine Doppelung mehr.
- `collapseRepeats` deckt jetzt Phrasen bis **Länge 8** ab (vorher 5).
- **Eigennamen-Aliase:** „Hose Cover" / „Hoso kawa" / „Hosokava" → **„Hosokawa"**; Hosokawa auch ins Technik-Glossar aufgenommen.

### Verifiziert (simulierter Android-Quirk)
Mehrfaches Senden derselben Liste ergibt: „wenn da wegen Kundschaft das gesprochen wird **Hosokawa** und so" — **keine** Doppelung.

## Tests
Neuer Dedup-/Alias-Test. Alle 12 Transkriptions-Tests grün.

https://claude.ai/code/session_01ShVpvnvAWB2rxihP9tW1WR

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShVpvnvAWB2rxihP9tW1WR)_