### PR TITLE
KI-Assistent: lokaler Chat (WebLLM) mit Gedächtnis und Formular-Aktionen

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ und per **WhatsApp / Teilen** weitergeben – **auch offline**.
   Erstell-Zeitstempel.
 - 📤 **Teilen** – natives Teilen (WhatsApp, E-Mail …); Fallback auf Download.
 - 📴 **Offline-fähig** – Service Worker cacht die App inkl. PDF-Bibliothek.
+- 💬 **KI-Assistent (lokal)** – ein Chat-Assistent, dessen Sprachmodell
+  **komplett im Browser** läuft (WebLLM/WebGPU) – **ohne API-Schlüssel und ohne
+  Server**. Er beantwortet Fragen, hilft beim Formulieren und kann die Bemerkung
+  **zusammenfassen / in Stichpunkte wandeln / verständlicher schreiben** und das
+  Ergebnis ins Feld übernehmen. Über **„merke dir: …“** lernt er Fakten, die
+  lokal (IndexedDB) gespeichert und in späteren Gesprächen genutzt werden.
+  Voraussetzung: aktuelles Chrome/Edge mit WebGPU; der erste Modell-Download ist
+  groß und wird danach gecacht.
 - ⚡ **Komfort** – Auto-Vervollständigung früherer Eingaben, Spracheingabe für
   Bemerkungen, Hell-/Dunkelmodus, Entwurf-Wiederherstellung gegen Datenverlust.
 
@@ -48,6 +56,9 @@ js/annotate.js      Foto-Markierung (Canvas)
 js/scan.js          Arbeitskarten-Scan (OCR via Tesseract.js, mehrere Rotationen)
 js/cardparse.js     Feld-Extraktion aus dem OCR-Text
 js/store.js         localStorage: Einstellungen, Vorschläge, Entwurf
+js/chat.js          KI-Assistent: Chat-Fenster, Schnellaktionen auf die Bemerkung
+js/aiengine.js      Lokales Sprachmodell (WebLLM/WebGPU, on-demand vom CDN)
+js/aimemory.js      Gedächtnis des Assistenten (IndexedDB, „merke dir …“)
 sw.js               Service Worker (Offline-Cache; OCR-Dateien lazy gecacht)
 manifest.json       PWA-Manifest (installierbar)
 vendor/jspdf…       jsPDF (lokal gehostet, offline)

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ und per **WhatsApp / Teilen** weitergeben – **auch offline**.
   **zusammenfassen / in Stichpunkte wandeln / verständlicher schreiben** und das
   Ergebnis ins Feld übernehmen. Über **„merke dir: …“** lernt er Fakten, die
   lokal (IndexedDB) gespeichert und in späteren Gesprächen genutzt werden.
-  Voraussetzung: aktuelles Chrome/Edge mit WebGPU; der erste Modell-Download ist
-  groß und wird danach gecacht.
+  **Läuft auch auf dem Handy:** auf Mobilgeräten wird automatisch ein kleines
+  Modell (~0,5 GB) gewählt, am PC ein stärkeres – manuell umschaltbar.
+  Voraussetzung: WebGPU (Handy: aktuelles Chrome/Android bzw. Safari ab iOS 18;
+  PC: Chrome/Edge). Der erste Modell-Download wird danach gecacht.
 - ⚡ **Komfort** – Auto-Vervollständigung früherer Eingaben, Spracheingabe für
   Bemerkungen, Hell-/Dunkelmodus, Entwurf-Wiederherstellung gegen Datenverlust.
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -718,3 +718,75 @@ footer.app-foot { text-align: center; color: var(--text-muted); font-size: 12px;
   background: var(--surface-2); cursor: pointer; font-size: 16px; color: var(--text-muted);
 }
 .tr-item-btn:hover { color: var(--accent); border-color: var(--accent); }
+
+/* ===================== KI-Assistent (Chat) ===================== */
+.fab-chat {
+  position: fixed; right: 16px; bottom: calc(88px + var(--safe-bottom)); z-index: 90;
+  width: 60px; height: 60px; border-radius: 50%; border: none; cursor: pointer;
+  background: linear-gradient(135deg, #6d28d9, #2563eb);
+  color: #fff; font-size: 26px; box-shadow: var(--shadow-lg);
+  display: grid; place-items: center;
+}
+.fab-chat:active { transform: scale(.94); }
+
+.chat-body {
+  flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 12px;
+  padding: 16px; padding-bottom: calc(16px + var(--safe-bottom)); background: var(--bg);
+}
+.chat-note {
+  font-size: 12px; line-height: 1.5; color: var(--text-muted);
+  background: var(--surface-2); border: 1px solid var(--border);
+  border-left: 4px solid var(--accent); border-radius: var(--radius-sm); padding: 10px 12px;
+}
+.chat-model { display: flex; align-items: center; gap: 10px; font-size: 13px; font-weight: 700; color: var(--text); }
+.chat-model select {
+  flex: 1; padding: 9px 10px; border-radius: var(--radius-sm);
+  border: 1.5px solid var(--border); background: var(--surface); color: var(--text); font-size: 13px;
+}
+.chat-status {
+  font-size: 13px; font-weight: 600; color: var(--accent-strong);
+  background: var(--accent-soft); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 10px 12px;
+}
+.chat-messages {
+  flex: 1; min-height: 180px; overflow-y: auto; display: flex; flex-direction: column; gap: 10px;
+  background: var(--surface); border: 1.5px solid var(--border); border-radius: var(--radius-sm); padding: 14px;
+}
+.chat-empty { color: var(--text-muted); font-size: 14px; line-height: 1.5; }
+.msg { display: flex; flex-direction: column; gap: 4px; max-width: 88%; }
+.msg-user { align-self: flex-end; align-items: flex-end; }
+.msg-ai { align-self: flex-start; align-items: flex-start; }
+.msg-text {
+  padding: 10px 13px; border-radius: var(--radius-sm); font-size: 15px; line-height: 1.55;
+  white-space: pre-wrap; word-break: break-word;
+}
+.msg-user .msg-text { background: var(--accent); color: #fff; border-bottom-right-radius: 4px; }
+.msg-ai .msg-text { background: var(--surface-2); color: var(--text); border: 1px solid var(--border); border-bottom-left-radius: 4px; }
+.msg-tools { display: flex; }
+.chat-caret { opacity: .6; animation: pulse 1s infinite; }
+.chat-quick { display: flex; flex-wrap: wrap; gap: 8px; }
+.chat-chip {
+  background: var(--surface-2); border: 1.5px solid var(--border); color: var(--accent);
+  border-radius: 999px; padding: 8px 13px; font-size: 13px; font-weight: 700; cursor: pointer;
+}
+.chat-chip:hover { border-color: var(--accent); }
+.chat-chip:disabled { opacity: .45; cursor: not-allowed; }
+.chat-input-row { display: flex; gap: 8px; }
+.chat-input-row input {
+  flex: 1; padding: 12px 14px; border-radius: var(--radius-sm);
+  border: 1.5px solid var(--border); background: var(--surface); color: var(--text); font-size: 15px;
+}
+.chat-input-row .btn { flex: 0 0 auto; }
+.chat-mem { border-top: 1px solid var(--border); padding-top: 10px; }
+.chat-mem-toggle { background: none; border: none; color: var(--accent); font-weight: 700; font-size: 13px; cursor: pointer; padding: 4px 0; }
+.chat-mem-panel { display: none; margin-top: 8px; flex-direction: column; gap: 8px; }
+.chat-mem-panel.open { display: flex; }
+.chat-mem-empty { color: var(--text-muted); font-size: 13px; line-height: 1.5; }
+.chat-mem-item {
+  display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text);
+  background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 8px 10px;
+}
+.chat-mem-item span { flex: 1; }
+.chat-mem-del { flex: 0 0 auto; background: none; border: none; cursor: pointer; font-size: 15px; color: var(--text-muted); }
+.chat-mem-del:hover { color: var(--danger); }
+.chat-mem-clearbtn { align-self: flex-start; color: var(--danger); border-color: var(--border); }

--- a/index.html
+++ b/index.html
@@ -279,6 +279,9 @@
   <!-- Schwebe-Knopf: Live-Mitschrift starten (Echtzeit-Transkription) -->
   <button class="fab-rec" id="fabRec" type="button" aria-label="Live-Mitschrift" title="Live-Mitschrift">🎙️</button>
 
+  <!-- Schwebe-Knopf: KI-Assistent (läuft lokal auf dem Gerät) -->
+  <button class="fab-chat" id="fabChat" type="button" aria-label="KI-Assistent" title="KI-Assistent">💬</button>
+
   <!-- Live-Mitschrift (Echtzeit-Transkription) -->
   <div class="modal" id="trModal" role="dialog" aria-modal="true" aria-label="Live-Mitschrift">
     <div class="modal-head">
@@ -315,6 +318,46 @@
       <div class="tr-saved">
         <div class="tr-saved-title">📁 Gespeicherte Mitschriften</div>
         <div id="trList"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- KI-Assistent (lokales Modell, kein Server) -->
+  <div class="modal" id="chatModal" role="dialog" aria-modal="true" aria-label="KI-Assistent">
+    <div class="modal-head">
+      <button id="chatClose" type="button">✕ Schließen</button>
+      <h2>💬 KI-Assistent</h2>
+      <button id="chatClear" type="button">🗑 Verlauf</button>
+    </div>
+    <div class="chat-body">
+      <div class="chat-note">
+        Läuft komplett auf deinem Gerät – ohne Internet-Dienst, ohne Konto. Beim ersten Start lädt einmalig ein Modell (groß, WLAN empfohlen) und wird danach gespeichert.
+      </div>
+      <label class="chat-model">
+        <span>Modell</span>
+        <select id="chatModel" aria-label="KI-Modell"></select>
+      </label>
+      <div class="chat-status hidden" id="chatStatus" role="status" aria-live="polite"></div>
+
+      <div class="chat-messages" id="chatMessages" aria-live="polite" role="log"></div>
+
+      <div class="chat-quick" aria-label="Schnellaktionen für die Bemerkung">
+        <button class="chat-chip" data-kind="summary" type="button">📝 Bemerkung kürzen</button>
+        <button class="chat-chip" data-kind="bullets" type="button">• Stichpunkte</button>
+        <button class="chat-chip" data-kind="clearer" type="button">✨ Verständlicher</button>
+      </div>
+
+      <div class="chat-input-row">
+        <input id="chatInput" type="text" placeholder="Frage stellen oder „merke dir: …“" autocomplete="off">
+        <button class="btn btn-primary" id="chatSend" type="button">Senden</button>
+      </div>
+
+      <div class="chat-mem">
+        <button class="chat-mem-toggle" id="chatMemToggle" type="button">🧠 Gedächtnis anzeigen/verbergen</button>
+        <div class="chat-mem-panel" id="chatMemPanel">
+          <div id="chatMemList"></div>
+          <button class="chat-chip chat-mem-clearbtn" id="chatMemClear" type="button">Gesamtes Gedächtnis löschen</button>
+        </div>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -331,7 +331,7 @@
     </div>
     <div class="chat-body">
       <div class="chat-note">
-        Läuft komplett auf deinem Gerät – ohne Internet-Dienst, ohne Konto. Beim ersten Start lädt einmalig ein Modell (groß, WLAN empfohlen) und wird danach gespeichert.
+        Läuft komplett auf deinem Gerät – ohne Internet-Dienst, ohne Konto. Auf dem Handy wird automatisch ein kleines Modell gewählt. Beim ersten Start lädt es einmalig (WLAN empfohlen) und wird danach gespeichert.
       </div>
       <label class="chat-model">
         <span>Modell</span>

--- a/js/aiengine.js
+++ b/js/aiengine.js
@@ -8,11 +8,13 @@
 
 import { Settings } from './store.js';
 
-// Auswahl an MLC/WebLLM-Modellen. Default: gute Deutsch-Fähigkeit; Sparoption
-// für schwächere Geräte. Umschaltbar über die Einstellungen (Settings.aiModel).
+// Auswahl an MLC/WebLLM-Modellen, nach Gerätestärke gestaffelt. Auf dem Handy
+// ist ein kleines Modell Pflicht (RAM/Download), auf dem Desktop darf es größer
+// sein. Umschaltbar über die Einstellungen (Settings.aiModel).
 export const MODELS = {
-  standard: { id: 'Llama-3.2-3B-Instruct-q4f16_1-MLC', label: 'Standard – Llama 3.2 3B (~1,7 GB)' },
-  klein: { id: 'Qwen2.5-1.5B-Instruct-q4f16_1-MLC', label: 'Klein & schnell – Qwen2.5 1.5B (~1 GB)' },
+  winzig: { id: 'Qwen2.5-0.5B-Instruct-q4f16_1-MLC', label: 'Handy – Qwen2.5 0.5B (~0,5 GB)' },
+  klein: { id: 'Llama-3.2-1B-Instruct-q4f16_1-MLC', label: 'Mittel – Llama 3.2 1B (~0,9 GB)' },
+  standard: { id: 'Llama-3.2-3B-Instruct-q4f16_1-MLC', label: 'Stark – Llama 3.2 3B (~1,7 GB, Desktop)' },
 };
 
 const WEBLLM_LIB = 'https://esm.run/@mlc-ai/web-llm';
@@ -21,9 +23,25 @@ let engine = null;        // geladene WebLLM-Engine
 let loadedId = null;      // welches Modell ist aktuell geladen
 let loadingPromise = null; // Promise während des Ladens (verhindert Doppel-Laden)
 
-// Läuft hier überhaupt ein KI-Modell? WebLLM braucht WebGPU.
+// Läuft hier überhaupt ein KI-Modell? WebLLM braucht WebGPU (auf dem Handy:
+// aktuelles Chrome für Android bzw. Safari ab iOS 18).
 export function isSupported() {
   return typeof navigator !== 'undefined' && 'gpu' in navigator;
+}
+
+// Handy oder Desktop? Bestimmt das Standard-Modell (kleines Modell fürs Handy).
+export function isMobile() {
+  try {
+    if (navigator.userAgentData && typeof navigator.userAgentData.mobile === 'boolean') {
+      return navigator.userAgentData.mobile;
+    }
+  } catch {}
+  return /Android|iPhone|iPad|iPod|Mobile/i.test((navigator && navigator.userAgent) || '');
+}
+
+// Sinnvolles Standard-Modell je nach Gerät (Handy klein, Desktop stark).
+export function defaultModelKey() {
+  return isMobile() ? 'winzig' : 'standard';
 }
 
 // Test-Haken: Ist window.__AI_MOCK gesetzt, wird das echte Modell NICHT geladen
@@ -32,10 +50,10 @@ function mock() {
   return (typeof window !== 'undefined') ? window.__AI_MOCK : null;
 }
 
-// Aktuell gewähltes Modell (aus den Einstellungen), mit sinnvollem Default.
+// Aktuell gewähltes Modell (aus den Einstellungen), sonst geräteabhängiger Default.
 export function currentModelKey() {
   const k = Settings.get().aiModel;
-  return MODELS[k] ? k : 'standard';
+  return MODELS[k] ? k : defaultModelKey();
 }
 export function currentModelId() {
   return MODELS[currentModelKey()].id;

--- a/js/aiengine.js
+++ b/js/aiengine.js
@@ -1,0 +1,91 @@
+// Lokaler KI-Assistent – das Sprachmodell läuft KOMPLETT im Browser (WebLLM,
+// WebGPU). Kein API-Schlüssel, kein Server: alles bleibt auf dem Gerät.
+//
+// Gleiche Idee wie der KI-Modus der Live-Mitschrift (Whisper über
+// transformers.js, siehe js/transcribe.js): das Modell wird beim ersten Start
+// einmalig vom CDN geladen und danach vom Browser gecacht. Folgestarts sind
+// schnell und funktionieren auch offline.
+
+import { Settings } from './store.js';
+
+// Auswahl an MLC/WebLLM-Modellen. Default: gute Deutsch-Fähigkeit; Sparoption
+// für schwächere Geräte. Umschaltbar über die Einstellungen (Settings.aiModel).
+export const MODELS = {
+  standard: { id: 'Llama-3.2-3B-Instruct-q4f16_1-MLC', label: 'Standard – Llama 3.2 3B (~1,7 GB)' },
+  klein: { id: 'Qwen2.5-1.5B-Instruct-q4f16_1-MLC', label: 'Klein & schnell – Qwen2.5 1.5B (~1 GB)' },
+};
+
+const WEBLLM_LIB = 'https://esm.run/@mlc-ai/web-llm';
+
+let engine = null;        // geladene WebLLM-Engine
+let loadedId = null;      // welches Modell ist aktuell geladen
+let loadingPromise = null; // Promise während des Ladens (verhindert Doppel-Laden)
+
+// Läuft hier überhaupt ein KI-Modell? WebLLM braucht WebGPU.
+export function isSupported() {
+  return typeof navigator !== 'undefined' && 'gpu' in navigator;
+}
+
+// Test-Haken: Ist window.__AI_MOCK gesetzt, wird das echte Modell NICHT geladen
+// (headless/CI hat kein WebGPU). Die App-Logik bleibt damit testbar.
+function mock() {
+  return (typeof window !== 'undefined') ? window.__AI_MOCK : null;
+}
+
+// Aktuell gewähltes Modell (aus den Einstellungen), mit sinnvollem Default.
+export function currentModelKey() {
+  const k = Settings.get().aiModel;
+  return MODELS[k] ? k : 'standard';
+}
+export function currentModelId() {
+  return MODELS[currentModelKey()].id;
+}
+
+// Lädt das Modell on demand. onProgress({ text, progress }) für die Anzeige.
+export async function ensureEngine(modelId, onProgress) {
+  if (mock()) return mock();
+  if (!isSupported()) throw new Error('NO_WEBGPU');
+  if (engine && loadedId === modelId) return engine;
+  if (loadingPromise) return loadingPromise;
+
+  loadingPromise = (async () => {
+    const webllm = await import(/* @vite-ignore */ WEBLLM_LIB);
+    const eng = await webllm.CreateMLCEngine(modelId, {
+      initProgressCallback: (r) => {
+        if (onProgress) onProgress({ text: r.text || '', progress: r.progress || 0 });
+      },
+    });
+    engine = eng;
+    loadedId = modelId;
+    return eng;
+  })();
+
+  try {
+    return await loadingPromise;
+  } finally {
+    loadingPromise = null;
+  }
+}
+
+// Streamt eine Antwort. messages = [{ role, content }], onToken(deltaText) für
+// die Live-Ausgabe. Gibt den vollständigen Antworttext zurück.
+export async function chatStream(modelId, messages, onToken, onProgress) {
+  const m = mock();
+  if (m) return m.chatStream(messages, onToken);
+
+  const eng = await ensureEngine(modelId, onProgress);
+  const stream = await eng.chat.completions.create({
+    messages,
+    stream: true,
+    temperature: 0.6,
+  });
+  let full = '';
+  for await (const chunk of stream) {
+    const delta = (chunk && chunk.choices && chunk.choices[0] && chunk.choices[0].delta && chunk.choices[0].delta.content) || '';
+    if (delta) {
+      full += delta;
+      if (onToken) onToken(delta);
+    }
+  }
+  return full;
+}

--- a/js/aimemory.js
+++ b/js/aimemory.js
@@ -1,0 +1,87 @@
+// Gedächtnis des KI-Assistenten – das "selbständige Lernen" ohne Server.
+// Was der Nutzer der KI beibringt ("merke dir: …"), wird hier lokal gespeichert
+// (IndexedDB, rein auf dem Gerät) und in jedem neuen Gespräch als Kontext
+// vorangestellt. So wird der Assistent über die Zeit nützlicher, ohne je Daten
+// nach außen zu senden. Aufbau analog zum Doku-Archiv (js/archive.js).
+
+const DB = 'techdoku-ai';
+const STORE = 'memory';
+const MAX = 200; // älteste darüber hinaus werden beim Speichern entfernt
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const rq = indexedDB.open(DB, 1);
+    rq.onupgradeneeded = () => {
+      const db = rq.result;
+      if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE, { keyPath: 'id' });
+    };
+    rq.onsuccess = () => resolve(rq.result);
+    rq.onerror = () => reject(rq.error);
+  });
+}
+
+function withStore(mode, fn) {
+  return openDB().then((db) => new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, mode);
+    const store = tx.objectStore(STORE);
+    const out = fn(store);
+    tx.oncomplete = () => resolve(out && out._result !== undefined ? out._result : out);
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  }));
+}
+
+function newId() {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+}
+
+export const Memory = {
+  // Alle Einträge, neueste zuerst.
+  async list() {
+    return withStore('readonly', (store) => {
+      const holder = {};
+      store.getAll().onsuccess = (e) => { holder._result = (e.target.result || []).sort((a, b) => b.savedAt - a.savedAt); };
+      return holder;
+    });
+  },
+
+  // Nur die vom Nutzer beigebrachten Fakten (für den Gesprächs-Kontext).
+  async facts() {
+    return (await this.list()).filter((r) => r.kind === 'fact');
+  },
+
+  async add({ text, kind } = {}) {
+    const rec = { id: newId(), text: String(text || '').trim(), kind: kind || 'fact', savedAt: Date.now() };
+    if (!rec.text) return null;
+    await withStore('readwrite', (store) => { store.put(rec); });
+    const all = await this.list();
+    if (all.length > MAX) {
+      const drop = all.slice(MAX);
+      await withStore('readwrite', (store) => { drop.forEach((d) => store.delete(d.id)); });
+    }
+    return rec;
+  },
+
+  async remove(id) {
+    return withStore('readwrite', (store) => { store.delete(id); });
+  },
+
+  async clear() {
+    return withStore('readwrite', (store) => { store.clear(); });
+  },
+
+  // Kompakter System-Prompt-Block aus den gespeicherten Fakten.
+  async buildContext() {
+    const facts = await this.facts();
+    if (!facts.length) return '';
+    return 'Folgendes hat sich der Nutzer von dir merken lassen – berücksichtige es, wenn es passt:\n'
+      + facts.map((f) => '- ' + f.text).join('\n');
+  },
+};
+
+// Erkennt Lern-Befehle wie "merke dir: …", "lern …", "notiere …".
+// Gibt den zu merkenden Text zurück (oder null).
+export function detectTeach(text) {
+  const m = String(text || '').match(/^\s*(?:merk(?:e)?\s+dir|lern(?:e)?|notiere|behalte)\b\s*[:,-]?\s*(.+)/is);
+  return m ? m[1].trim() : null;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -7,6 +7,7 @@ import { openZoneCalibrator } from './zonecal.js';
 import { zoneLabel } from './zones.js';
 import { openSignaturePad } from './signature.js';
 import { initTranscribe } from './transcribe.js';
+import { initChat } from './chat.js';
 
 const $ = (id) => document.getElementById(id);
 const MAX_IMAGES = 9;
@@ -42,13 +43,15 @@ function init() {
   initInstall();
   initZones();
   initSignature();
-  initTranscribe((text) => {
-    // Mitschrift in das Bemerkungsfeld übernehmen (an vorhandenen Text anhängen).
+  // An das Bemerkungsfeld anhängen (von Mitschrift UND KI-Assistent genutzt).
+  const appendBemerkung = (text) => {
     const ta = $('bemerkung');
     ta.value = (ta.value ? ta.value.trim() + '\n\n' : '') + text;
     ta.dispatchEvent(new Event('input', { bubbles: true }));
     saveDraft();
-  });
+  };
+  initTranscribe(appendBemerkung);
+  initChat(appendBemerkung);
   refreshSuggestions();
   setToday();
   const last = Settings.get().lastVerantwortlich;

--- a/js/chat.js
+++ b/js/chat.js
@@ -224,7 +224,7 @@ function open() {
   $('chatModal').classList.add('open');
   document.body.style.overflow = 'hidden';
   if (!isSupported()) {
-    setStatus('Hinweis: Dieses Gerät unterstützt das lokale KI-Modell nicht (WebGPU fehlt). Bitte ein aktuelles Chrome oder Edge verwenden.');
+    setStatus('Hinweis: Dieses Gerät/Browser unterstützt das lokale KI-Modell nicht (WebGPU fehlt). Auf dem Handy: aktuelles Chrome (Android) bzw. Safari ab iOS 18; am PC: Chrome oder Edge.');
   }
   render();
   setTimeout(() => { const i = $('chatInput'); if (i && isSupported()) i.focus(); }, 50);

--- a/js/chat.js
+++ b/js/chat.js
@@ -1,0 +1,287 @@
+// KI-Assistent – Chat-Fenster der App. Spricht mit dem lokal im Browser
+// laufenden Modell (js/aiengine.js) und nutzt das lokale Gedächtnis
+// (js/aimemory.js). Kann zusätzlich "im Formular handeln": die aktuelle
+// Bemerkung zusammenfassen / in Stichpunkte wandeln / verständlicher schreiben
+// und das Ergebnis ins Bemerkungsfeld übernehmen.
+
+import { isSupported, chatStream, currentModelId, currentModelKey, MODELS } from './aiengine.js';
+import { Memory, detectTeach } from './aimemory.js';
+import { Settings } from './store.js';
+
+const $ = (id) => document.getElementById(id);
+
+const BASE_PERSONA =
+  'Du bist ein hilfreicher Assistent, der komplett offline auf dem Gerät läuft, '
+  + 'eingebettet in eine App für technische Dokumentationen (Reklamationen, '
+  + 'Arbeitskarten, Bemerkungen). Antworte auf Deutsch, knapp und sachlich. '
+  + 'Hilf beim Formulieren, Zusammenfassen und Beantworten von Fragen.';
+
+const HISTORY_KEY = 'techdoku_chat';
+const HISTORY_MAX = 40; // gespeicherte Nachrichten (für den Kontext genutzt: die letzten ~12)
+
+let history = [];     // [{ role:'user'|'assistant', content }]
+let busy = false;     // gerade eine Antwort am Generieren?
+let onToBemerkung = null; // Callback aus app.js (hängt Text an das Bemerkungsfeld an)
+
+/* ---------- Speicher des Verlaufs (klein, daher localStorage) ---------- */
+function loadHistory() { try { history = JSON.parse(localStorage.getItem(HISTORY_KEY)) || []; } catch { history = []; } }
+function saveHistory() { try { localStorage.setItem(HISTORY_KEY, JSON.stringify(history.slice(-HISTORY_MAX))); } catch {} }
+
+function esc(s) { return String(s || '').replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
+
+/* ---------- kleiner Toast (App.toast ist hier nicht erreichbar) ---------- */
+let toastTimer;
+function toast(msg) {
+  const t = $('toast');
+  if (!t) return;
+  t.className = 'toast show'; t.textContent = msg; t.onclick = null;
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => t.classList.remove('show'), 2400);
+}
+
+/* ---------- Anzeige der Nachrichten ---------- */
+function render() {
+  const box = $('chatMessages');
+  if (!box) return;
+  if (!history.length) {
+    box.innerHTML = '<div class="chat-empty">Stell eine Frage, lass dir beim Formulieren helfen – oder bring mir etwas bei: '
+      + '<em>„merke dir: …“</em>. Alles bleibt auf deinem Gerät.</div>';
+    return;
+  }
+  box.innerHTML = history.map((m, i) => bubble(m, i)).join('');
+  box.scrollTop = box.scrollHeight;
+}
+
+function bubble(m, i) {
+  const cls = m.role === 'user' ? 'msg-user' : 'msg-ai';
+  const tools = (m.role === 'assistant' && m.content && i !== -1)
+    ? `<div class="msg-tools"><button class="chat-chip" data-act="toBemerkung" data-i="${i}" type="button">⬇️ In Bemerkung</button></div>`
+    : '';
+  return `<div class="msg ${cls}"><div class="msg-text">${esc(m.content)}</div>${tools}</div>`;
+}
+
+// Zeigt den gerade streamenden Antworttext live an (ohne History zu verändern).
+function renderStreaming(partial) {
+  const box = $('chatMessages');
+  if (!box) return;
+  const live = `<div class="msg msg-ai"><div class="msg-text">${esc(partial)}<span class="chat-caret">▍</span></div></div>`;
+  box.innerHTML = history.map((m, i) => bubble(m, i)).join('') + live;
+  box.scrollTop = box.scrollHeight;
+}
+
+/* ---------- Modell-/Status-Anzeige ---------- */
+function setStatus(text) {
+  const el = $('chatStatus');
+  if (!el) return;
+  el.textContent = text || '';
+  el.classList.toggle('hidden', !text);
+}
+
+function setBusy(on) {
+  busy = on;
+  const send = $('chatSend');
+  const input = $('chatInput');
+  if (send) send.disabled = on;
+  if (input) input.disabled = on;
+  document.querySelectorAll('#chatModal .chat-quick button').forEach((b) => { b.disabled = on; });
+}
+
+/* ---------- Gespräch mit dem Modell ---------- */
+async function ask(messages, onToken) {
+  const modelId = currentModelId();
+  let firstToken = true;
+  return chatStream(modelId, messages, (delta) => {
+    if (firstToken) { setStatus(''); firstToken = false; }
+    onToken(delta);
+  }, (p) => {
+    // Lade-Fortschritt beim ersten Start (großer Modell-Download)
+    const pct = p && p.progress ? ` ${Math.round(p.progress * 100)}%` : '';
+    setStatus((p && p.text ? p.text : 'Modell wird geladen …') + pct);
+  });
+}
+
+async function buildMessages(userContent) {
+  const ctx = await Memory.buildContext();
+  const sys = { role: 'system', content: BASE_PERSONA + (ctx ? '\n\n' + ctx : '') };
+  const recent = history.slice(-12).map((m) => ({ role: m.role, content: m.content }));
+  return [sys, ...recent, { role: 'user', content: userContent }];
+}
+
+// Generische Antwort-Runde: hängt die Nutzer-Nachricht an, streamt die Antwort,
+// speichert beides. `displayUser` = was im Verlauf als Nutzer-Bubble steht
+// (bei Schnellaktionen ein lesbarer Hinweis statt des langen Prompts).
+async function runTurn(promptContent, displayUser) {
+  if (busy) return;
+  if (!isSupported()) { toast('Dieses Gerät unterstützt das lokale KI-Modell nicht (WebGPU fehlt).'); return; }
+  setBusy(true);
+
+  history.push({ role: 'user', content: displUserText(displayUser, promptContent) });
+  saveHistory();
+  render();
+  setStatus('Denkt nach …');
+
+  let answer = '';
+  try {
+    const messages = await buildMessages(promptContent);
+    answer = await ask(messages, (delta) => { answer += delta; renderStreaming(answer); });
+  } catch (e) {
+    setStatus('');
+    setBusy(false);
+    const why = (e && e.message === 'NO_WEBGPU')
+      ? 'Dieses Gerät unterstützt das lokale KI-Modell nicht (WebGPU fehlt). Nutze ein aktuelles Chrome/Edge.'
+      : 'Das Modell konnte nicht antworten. Beim ersten Start braucht der Download etwas Geduld und WLAN.';
+    history.push({ role: 'assistant', content: why });
+    saveHistory();
+    render();
+    return null;
+  }
+
+  setStatus('');
+  history.push({ role: 'assistant', content: answer.trim() });
+  saveHistory();
+  render();
+  setBusy(false);
+  return answer.trim();
+}
+
+function displUserText(displayUser, prompt) {
+  return displayUser || prompt;
+}
+
+/* ---------- Senden aus dem Eingabefeld ---------- */
+async function send() {
+  const input = $('chatInput');
+  const text = (input.value || '').trim();
+  if (!text || busy) return;
+  input.value = '';
+
+  // Lern-Befehl? Dann direkt ins Gedächtnis, ohne das Modell zu bemühen.
+  const learn = detectTeach(text);
+  if (learn) {
+    await Memory.add({ text: learn, kind: 'fact' });
+    history.push({ role: 'user', content: text });
+    history.push({ role: 'assistant', content: '🧠 Gemerkt: „' + learn + '“. Ich berücksichtige das künftig.' });
+    saveHistory();
+    render();
+    refreshMemoryList();
+    return;
+  }
+
+  await runTurn(text, null);
+}
+
+/* ---------- Schnellaktionen auf dem Bemerkungsfeld ---------- */
+function bemerkungText() {
+  const ta = $('bemerkung');
+  return ta ? (ta.value || '').trim() : '';
+}
+
+async function quick(kind) {
+  const text = bemerkungText();
+  if (!text) { toast('Bitte zuerst etwas in das Bemerkungsfeld schreiben.'); return; }
+  const prompts = {
+    summary: { label: '📝 Bemerkung kürzen', p: `Fasse die folgende technische Bemerkung in 2–3 knappen Sätzen zusammen. Gib nur die Zusammenfassung aus:\n\n"""${text}"""` },
+    bullets: { label: '• In Stichpunkte', p: `Wandle die folgende Bemerkung in klare Stichpunkte um (eine Zeile je Punkt, beginnend mit "- "). Gib nur die Stichpunkte aus:\n\n"""${text}"""` },
+    clearer: { label: '✨ Verständlicher schreiben', p: `Schreibe die folgende Bemerkung in sauberem, verständlichem Deutsch neu, ohne den Inhalt zu verändern. Gib nur den neuen Text aus:\n\n"""${text}"""` },
+  };
+  const sel = prompts[kind];
+  if (!sel) return;
+  await runTurn(sel.p, sel.label);
+}
+
+/* ---------- Gedächtnis-Ansicht ---------- */
+async function refreshMemoryList() {
+  const wrap = $('chatMemList');
+  if (!wrap) return;
+  const facts = await Memory.facts();
+  if (!facts.length) {
+    wrap.innerHTML = '<div class="chat-mem-empty">Noch nichts gemerkt. Schreib z. B. „merke dir: Kunde Müller bekommt PDFs ohne Fotos“.</div>';
+    return;
+  }
+  wrap.innerHTML = facts.map((f) =>
+    `<div class="chat-mem-item"><span>${esc(f.text)}</span>`
+    + `<button class="chat-mem-del" data-id="${f.id}" type="button" title="Vergessen" aria-label="Vergessen">🗑</button></div>`
+  ).join('');
+}
+
+function toggleMemory() {
+  const panel = $('chatMemPanel');
+  if (!panel) return;
+  const open = panel.classList.toggle('open');
+  if (open) refreshMemoryList();
+}
+
+/* ---------- Modell-Auswahl ---------- */
+function fillModelSelect() {
+  const sel = $('chatModel');
+  if (!sel) return;
+  sel.innerHTML = Object.entries(MODELS).map(([k, m]) => `<option value="${k}">${esc(m.label)}</option>`).join('');
+  sel.value = currentModelKey();
+}
+
+/* ---------- Öffnen / Schließen ---------- */
+function open() {
+  $('chatModal').classList.add('open');
+  document.body.style.overflow = 'hidden';
+  if (!isSupported()) {
+    setStatus('Hinweis: Dieses Gerät unterstützt das lokale KI-Modell nicht (WebGPU fehlt). Bitte ein aktuelles Chrome oder Edge verwenden.');
+  }
+  render();
+  setTimeout(() => { const i = $('chatInput'); if (i && isSupported()) i.focus(); }, 50);
+}
+function close() {
+  $('chatModal').classList.remove('open');
+  document.body.style.overflow = '';
+}
+
+/* ---------- Init ---------- */
+export function initChat(toBemerkung) {
+  onToBemerkung = toBemerkung;
+  const fab = $('fabChat');
+  if (!fab) return;
+
+  loadHistory();
+  fillModelSelect();
+
+  fab.onclick = open;
+  $('chatClose').onclick = close;
+  $('chatSend').onclick = send;
+  $('chatInput').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
+  });
+
+  $('chatClear').onclick = () => {
+    if (!history.length || confirm('Gesprächsverlauf leeren? (Das Gedächtnis bleibt erhalten.)')) {
+      history = []; saveHistory(); render();
+    }
+  };
+
+  document.querySelectorAll('#chatModal .chat-quick button').forEach((b) => {
+    b.onclick = () => quick(b.dataset.kind);
+  });
+
+  // Antwort-Bubbles: "In Bemerkung" übernehmen (gleiches Anhänge-Muster wie die Mitschrift)
+  $('chatMessages').addEventListener('click', (e) => {
+    const b = e.target.closest('[data-act="toBemerkung"]');
+    if (!b) return;
+    const m = history[+b.dataset.i];
+    if (m && typeof onToBemerkung === 'function') { onToBemerkung(m.content); toast('In das Bemerkungsfeld übernommen.'); }
+  });
+
+  // Gedächtnis-Panel
+  $('chatMemToggle').onclick = toggleMemory;
+  $('chatMemClear').onclick = async () => {
+    if (confirm('Das gesamte Gedächtnis löschen?')) { await Memory.clear(); refreshMemoryList(); toast('Gedächtnis geleert.'); }
+  };
+  $('chatMemList').addEventListener('click', async (e) => {
+    const b = e.target.closest('.chat-mem-del');
+    if (!b) return;
+    await Memory.remove(b.dataset.id);
+    refreshMemoryList();
+  });
+
+  // Modell-Wahl speichern (greift beim nächsten Laden)
+  $('chatModel').onchange = (e) => { Settings.set({ aiModel: e.target.value }); toast('Modell gewählt – wird beim nächsten Start geladen.'); };
+
+  render();
+}

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-31';
+const CACHE = 'techdoku-v2026-32';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier
@@ -20,6 +20,9 @@ const ASSETS = [
   './js/archive.js',
   './js/signature.js',
   './js/transcribe.js',
+  './js/chat.js',
+  './js/aiengine.js',
+  './js/aimemory.js',
   './vendor/jspdf.umd.min.js',
   './manifest.json',
   './icon-192.png',

--- a/tests/chat-ui.spec.js
+++ b/tests/chat-ui.spec.js
@@ -69,6 +69,20 @@ test('KI-Assistent: Schnellaktion schreibt Ergebnis in die Bemerkung', async ({ 
   await expect(page.locator('#bemerkung')).toHaveValue(/Werkstück hat Riss[\s\S]*Antwort auf:/);
 });
 
+test('KI-Assistent: Handy bekommt automatisch ein kleines Modell', async ({ page }, testInfo) => {
+  await injectFakeAI(page);
+  await page.goto('/');
+  await page.click('#fabChat');
+
+  // Das Handy-Modell steht immer zur Auswahl …
+  await expect(page.locator('#chatModel option[value="winzig"]')).toHaveCount(1);
+
+  // … und ist auf dem Handy automatisch vorgewählt (Desktop: starkes Modell).
+  const val = await page.locator('#chatModel').inputValue();
+  if (testInfo.project.name.includes('mobile')) expect(val).toBe('winzig');
+  else expect(val).toBe('standard');
+});
+
 test('KI-Assistent: Schnellaktion ohne Bemerkung gibt Hinweis', async ({ page }) => {
   await injectFakeAI(page);
   await page.goto('/');

--- a/tests/chat-ui.spec.js
+++ b/tests/chat-ui.spec.js
@@ -1,0 +1,79 @@
+const { test, expect } = require('@playwright/test');
+
+// Das KI-Modell (WebLLM) braucht WebGPU, das es im Headless-Chromium nicht
+// gibt. Wir gaukeln WebGPU vor und ersetzen die Engine durch eine schlanke
+// Fake-Antwort (window.__AI_MOCK), die js/aiengine.js bevorzugt nutzt. So
+// lassen sich Oberfläche, Gedächtnis und das Übernehmen in die Bemerkung
+// testen – ohne echten Modell-Download.
+async function injectFakeAI(page) {
+  await page.addInitScript(() => {
+    try { Object.defineProperty(navigator, 'gpu', { value: {}, configurable: true }); } catch {}
+    window.__AI_MOCK = {
+      chatStream(messages, onToken) {
+        const last = messages[messages.length - 1].content || '';
+        const reply = 'Antwort auf: ' + last.slice(0, 30);
+        for (const ch of reply) { if (onToken) onToken(ch); }
+        return Promise.resolve(reply);
+      },
+    };
+  });
+}
+
+test('KI-Assistent: Knopf öffnet Chat und beantwortet eine Frage', async ({ page }) => {
+  await injectFakeAI(page);
+  await page.goto('/');
+
+  await expect(page.locator('#fabChat')).toBeVisible();
+  await page.click('#fabChat');
+  await expect(page.locator('#chatModal')).toHaveClass(/open/);
+
+  await page.fill('#chatInput', 'Was ist eine Reklamation?');
+  await page.click('#chatSend');
+
+  await expect(page.locator('#chatMessages .msg-user')).toContainText('Was ist eine Reklamation?');
+  await expect(page.locator('#chatMessages .msg-ai')).toContainText('Antwort auf:');
+});
+
+test('KI-Assistent: lernt per „merke dir“ und zeigt es im Gedächtnis', async ({ page }) => {
+  await injectFakeAI(page);
+  await page.goto('/');
+  await page.click('#fabChat');
+
+  await page.fill('#chatInput', 'merke dir: Kunde Müller bekommt PDFs ohne Fotos');
+  await page.click('#chatSend');
+
+  await expect(page.locator('#chatMessages .msg-ai')).toContainText('Gemerkt');
+
+  await page.click('#chatMemToggle');
+  await expect(page.locator('#chatMemPanel')).toHaveClass(/open/);
+  await expect(page.locator('#chatMemList')).toContainText('Kunde Müller bekommt PDFs ohne Fotos');
+
+  // Vergessen-Knopf entfernt den Eintrag wieder
+  await page.click('#chatMemList .chat-mem-del');
+  await expect(page.locator('#chatMemList')).toContainText('Noch nichts gemerkt');
+});
+
+test('KI-Assistent: Schnellaktion schreibt Ergebnis in die Bemerkung', async ({ page }) => {
+  await injectFakeAI(page);
+  await page.goto('/');
+
+  await page.fill('#bemerkung', 'Werkstück hat Riss an der Kante, Maß außerhalb Toleranz.');
+  await page.click('#fabChat');
+
+  await page.click('.chat-quick button[data-kind="summary"]');
+  await expect(page.locator('#chatMessages .msg-user')).toContainText('Bemerkung kürzen');
+  await expect(page.locator('#chatMessages .msg-ai')).toContainText('Antwort auf:');
+
+  // Antwort in die Bemerkung übernehmen (wird angehängt)
+  await page.click('#chatMessages .msg-ai [data-act="toBemerkung"]');
+  await expect(page.locator('#bemerkung')).toHaveValue(/Werkstück hat Riss[\s\S]*Antwort auf:/);
+});
+
+test('KI-Assistent: Schnellaktion ohne Bemerkung gibt Hinweis', async ({ page }) => {
+  await injectFakeAI(page);
+  await page.goto('/');
+  await page.click('#fabChat');
+
+  await page.click('.chat-quick button[data-kind="bullets"]');
+  await expect(page.locator('#toast')).toContainText('Bemerkungsfeld');
+});


### PR DESCRIPTION
## Was ist neu

Ein **KI-Assistent**, der **komplett auf dem Gerät** läuft – **ohne API-Schlüssel und ohne Server**. Das Sprachmodell wird per **WebLLM/WebGPU** on demand vom CDN geladen und danach gecacht (gleiche Idee wie der bestehende Whisper-KI-Modus der Live-Mitschrift).

Damit werden die Vorgaben umgesetzt: „bau eine KI", „ohne API", „selbständig", „eigenständig lernen" und „im Formular handeln".

### Fähigkeiten
- 💬 **Chat** mit Streaming-Antwort, Verlauf in localStorage.
- 🧠 **Lernen ohne Server:** „**merke dir: …**" speichert Fakten lokal (IndexedDB). Sie werden jedem neuen Gespräch als Kontext vorangestellt → der Assistent wird über die Zeit nützlicher.
- 📝 **Im Formular handeln:** Schnellaktionen auf das Bemerkungsfeld – **kürzen / Stichpunkte / verständlicher** – Ergebnis lässt sich per Knopf ins Feld übernehmen (gleiches Anhänge-Muster wie die Live-Mitschrift).
- Modellwahl (Standard 3B / klein 1.5B) in den Einstellungen.

## Dateien
| Datei | Zweck |
|---|---|
| `js/aiengine.js` | WebLLM-Anbindung: lazy Laden mit Fortschritt, Streaming, WebGPU-Check, Modellwahl. Test-Haken `window.__AI_MOCK`. |
| `js/aimemory.js` | Gedächtnis (IndexedDB), `detectTeach()` für „merke dir …". |
| `js/chat.js` | Chat-UI, Schnellaktionen, Übernahme ins Bemerkungsfeld. |
| `index.html` / `css/styles.css` | Schwebe-Knopf 💬 + Modal im bestehenden Modal-Muster. |
| `js/app.js` | `initChat` eingehängt, gemeinsamer `appendBemerkung`-Helfer. |
| `sw.js` | Cache `v2026-32`, neue Dateien aufgenommen. |
| `tests/chat-ui.spec.js` | 4 E2E-Tests (Engine gemockt, da headless kein WebGPU). |

## Tests
`npx playwright test` → **82 bestanden** (74 bestehende + 8 neue, Mobile + Desktop).

## Ehrliche Grenzen
- Braucht **WebGPU** (aktuelles Chrome/Edge). Ohne WebGPU erscheint ein freundlicher Hinweis statt eines Fehlers.
- Erster Modell-Download ist groß (~0,5–2 GB, danach gecacht) – Größenordnung wie das vorhandene Whisper-Modell.
- Ein im Browser laufendes Modell ist kleiner/schwächer als Cloud-KI. „Lernen" ist **gedächtnisbasiert** (kein Feintuning). Echtes Tool-Calling/Agenten-Loop bewusst noch nicht enthalten (kleine On-Device-Modelle zu unzuverlässig) – erweiterbar angelegt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbmT5bBB85BGbCy9rVzdTk)_