### PR TITLE
KI-Assistent: durchgängig Qwen 2.5 (bestes kostenloses Modell für Deutsch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ und per **WhatsApp / Teilen** weitergeben – **auch offline**.
   **zusammenfassen / in Stichpunkte wandeln / verständlicher schreiben** und das
   Ergebnis ins Feld übernehmen. Über **„merke dir: …“** lernt er Fakten, die
   lokal (IndexedDB) gespeichert und in späteren Gesprächen genutzt werden.
-  **Läuft auch auf dem Handy:** auf Mobilgeräten wird automatisch ein kleines
-  Modell (~0,5 GB) gewählt, am PC ein stärkeres – manuell umschaltbar.
-  Voraussetzung: WebGPU (Handy: aktuelles Chrome/Android bzw. Safari ab iOS 18;
-  PC: Chrome/Edge). Der erste Modell-Download wird danach gecacht.
+  Verwendet **Qwen 2.5** (bestes kostenloses, mehrsprachiges On-Device-Modell mit
+  guter Deutsch-Fähigkeit). **Läuft auch auf dem Handy:** dort wird automatisch
+  die passende Größe gewählt (1.5B, ~1 GB; ältere Handys 0.5B), am PC das
+  stärkere 3B – manuell umschaltbar. Voraussetzung: WebGPU (Handy: aktuelles
+  Chrome/Android bzw. Safari ab iOS 18; PC: Chrome/Edge). Der erste Modell-
+  Download wird danach gecacht.
 - ⚡ **Komfort** – Auto-Vervollständigung früherer Eingaben, Spracheingabe für
   Bemerkungen, Hell-/Dunkelmodus, Entwurf-Wiederherstellung gegen Datenverlust.
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -773,10 +773,12 @@ footer.app-foot { text-align: center; color: var(--text-muted); font-size: 12px;
 .chat-chip:disabled { opacity: .45; cursor: not-allowed; }
 .chat-input-row { display: flex; gap: 8px; }
 .chat-input-row input {
-  flex: 1; padding: 12px 14px; border-radius: var(--radius-sm);
+  flex: 1 1 auto; min-width: 0; padding: 12px 14px; border-radius: var(--radius-sm);
   border: 1.5px solid var(--border); background: var(--surface); color: var(--text); font-size: 15px;
 }
-.chat-input-row .btn { flex: 0 0 auto; }
+/* Senden-Knopf NICHT auf volle Breite (die .btn-Basis ist width:100%): sonst
+   quetscht er das Eingabefeld auf ~30px und das Tippen zerfällt. */
+.chat-input-row .btn { flex: 0 0 auto; width: auto; }
 .chat-mem { border-top: 1px solid var(--border); padding-top: 10px; }
 .chat-mem-toggle { background: none; border: none; color: var(--accent); font-weight: 700; font-size: 13px; cursor: pointer; padding: 4px 0; }
 .chat-mem-panel { display: none; margin-top: 8px; flex-direction: column; gap: 8px; }

--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@
       </div>
 
       <div class="chat-input-row">
-        <input id="chatInput" type="text" placeholder="Frage stellen oder „merke dir: …“" autocomplete="off">
+        <input id="chatInput" type="text" placeholder="Frage stellen oder „merke dir: …“" lang="de" dir="ltr" inputmode="text" enterkeyhint="send" autocomplete="off" autocorrect="off" autocapitalize="sentences" spellcheck="false">
         <button class="btn btn-primary" id="chatSend" type="button">Senden</button>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -331,7 +331,7 @@
     </div>
     <div class="chat-body">
       <div class="chat-note">
-        Läuft komplett auf deinem Gerät – ohne Internet-Dienst, ohne Konto. Auf dem Handy wird automatisch ein kleines Modell gewählt. Beim ersten Start lädt es einmalig (WLAN empfohlen) und wird danach gespeichert.
+        Läuft komplett auf deinem Gerät – ohne Internet-Dienst, ohne Konto. Nutzt Qwen 2.5 (gute Deutsch-Fähigkeit); auf dem Handy automatisch in passender Größe. Beim ersten Start lädt es einmalig (WLAN empfohlen) und wird danach gespeichert.
       </div>
       <label class="chat-model">
         <span>Modell</span>

--- a/js/aiengine.js
+++ b/js/aiengine.js
@@ -8,13 +8,13 @@
 
 import { Settings } from './store.js';
 
-// Auswahl an MLC/WebLLM-Modellen, nach Gerätestärke gestaffelt. Auf dem Handy
-// ist ein kleines Modell Pflicht (RAM/Download), auf dem Desktop darf es größer
-// sein. Umschaltbar über die Einstellungen (Settings.aiModel).
+// Modelle der Qwen-2.5-Familie – bestes kostenloses, mehrsprachiges (deutsches)
+// On-Device-Modell in kleiner Größe. Nach Gerätestärke gestaffelt: Handy klein,
+// Desktop größer. Umschaltbar über die Einstellungen (Settings.aiModel).
 export const MODELS = {
-  winzig: { id: 'Qwen2.5-0.5B-Instruct-q4f16_1-MLC', label: 'Handy – Qwen2.5 0.5B (~0,5 GB)' },
-  klein: { id: 'Llama-3.2-1B-Instruct-q4f16_1-MLC', label: 'Mittel – Llama 3.2 1B (~0,9 GB)' },
-  standard: { id: 'Llama-3.2-3B-Instruct-q4f16_1-MLC', label: 'Stark – Llama 3.2 3B (~1,7 GB, Desktop)' },
+  winzig: { id: 'Qwen2.5-0.5B-Instruct-q4f16_1-MLC', label: 'Sparsam – Qwen 2.5 0.5B (~0,5 GB, ältere Handys)' },
+  klein: { id: 'Qwen2.5-1.5B-Instruct-q4f16_1-MLC', label: 'Empfohlen – Qwen 2.5 1.5B (~1 GB, Handy)' },
+  standard: { id: 'Qwen2.5-3B-Instruct-q4f16_1-MLC', label: 'Stark – Qwen 2.5 3B (~1,8 GB, Desktop)' },
 };
 
 const WEBLLM_LIB = 'https://esm.run/@mlc-ai/web-llm';
@@ -39,9 +39,11 @@ export function isMobile() {
   return /Android|iPhone|iPad|iPod|Mobile/i.test((navigator && navigator.userAgent) || '');
 }
 
-// Sinnvolles Standard-Modell je nach Gerät (Handy klein, Desktop stark).
+// Sinnvolles Standard-Modell je nach Gerät: Handy = empfohlenes 1.5B (beste
+// Balance auf modernen Handys), Desktop = stärkeres 3B. Ältere Handys können
+// in den Einstellungen auf das sparsame 0.5B-Modell wechseln.
 export function defaultModelKey() {
-  return isMobile() ? 'winzig' : 'standard';
+  return isMobile() ? 'klein' : 'standard';
 }
 
 // Test-Haken: Ist window.__AI_MOCK gesetzt, wird das echte Modell NICHT geladen

--- a/js/chat.js
+++ b/js/chat.js
@@ -11,10 +11,12 @@ import { Settings } from './store.js';
 const $ = (id) => document.getElementById(id);
 
 const BASE_PERSONA =
-  'Du bist ein hilfreicher Assistent, der komplett offline auf dem Gerät läuft, '
-  + 'eingebettet in eine App für technische Dokumentationen (Reklamationen, '
-  + 'Arbeitskarten, Bemerkungen). Antworte auf Deutsch, knapp und sachlich. '
-  + 'Hilf beim Formulieren, Zusammenfassen und Beantworten von Fragen.';
+  'Du antwortest AUSSCHLIESSLICH auf Deutsch – immer, egal in welcher Sprache die '
+  + 'Frage erscheint oder wirkt. Du bist ein hilfreicher Assistent, der komplett '
+  + 'offline auf dem Gerät läuft, eingebettet in eine App für technische '
+  + 'Dokumentationen (Reklamationen, Arbeitskarten, Bemerkungen). Antworte knapp '
+  + 'und sachlich. Hilf beim Formulieren, Zusammenfassen und Beantworten von Fragen. '
+  + 'Wichtig: Deine Antwort ist immer auf Deutsch.';
 
 const HISTORY_KEY = 'techdoku_chat';
 const HISTORY_MAX = 40; // gespeicherte Nachrichten (für den Kontext genutzt: die letzten ~12)
@@ -227,7 +229,10 @@ function open() {
     setStatus('Hinweis: Dieses Gerät/Browser unterstützt das lokale KI-Modell nicht (WebGPU fehlt). Auf dem Handy: aktuelles Chrome (Android) bzw. Safari ab iOS 18; am PC: Chrome oder Edge.');
   }
   render();
-  setTimeout(() => { const i = $('chatInput'); if (i && isSupported()) i.focus(); }, 50);
+  // KEIN verzögerter Fokus: ein setTimeout(...focus...) feuerte mitten ins
+  // Tippen und setzte den Cursor zurück → Zeichen landeten verdreht/am Anfang
+  // (besonders auf dem Handy). Der Nutzer tippt selbst ins Feld; auf dem Handy
+  // öffnet ein programmatischer Fokus ohnehin keine Tastatur.
 }
 function close() {
   $('chatModal').classList.remove('open');

--- a/tests/chat-ui.spec.js
+++ b/tests/chat-ui.spec.js
@@ -91,3 +91,19 @@ test('KI-Assistent: Schnellaktion ohne Bemerkung gibt Hinweis', async ({ page })
   await page.click('.chat-quick button[data-kind="bullets"]');
   await expect(page.locator('#toast')).toContainText('Bemerkungsfeld');
 });
+
+test('KI-Assistent: Eingabefeld ist breit genug und behält den Text (auch Umlaute)', async ({ page }) => {
+  // Regression: Der Senden-Knopf (Basis .btn = width:100%) quetschte das
+  // Eingabefeld auf ~30px; in so einem Mini-Feld zerfiel die Eingabe beim
+  // Tippen. Feld muss breit sein UND den getippten Text exakt behalten.
+  await injectFakeAI(page);
+  await page.goto('/');
+  await page.click('#fabChat');
+
+  const box = await page.locator('#chatInput').boundingBox();
+  expect(box.width).toBeGreaterThan(120);
+
+  const satz = 'Schöne Grüße äöü ß!';
+  await page.locator('#chatInput').pressSequentially(satz, { delay: 20 });
+  await expect(page.locator('#chatInput')).toHaveValue(satz);
+});

--- a/tests/chat-ui.spec.js
+++ b/tests/chat-ui.spec.js
@@ -74,12 +74,12 @@ test('KI-Assistent: Handy bekommt automatisch ein kleines Modell', async ({ page
   await page.goto('/');
   await page.click('#fabChat');
 
-  // Das Handy-Modell steht immer zur Auswahl …
+  // Das sparsame Handy-Modell steht immer zur Auswahl …
   await expect(page.locator('#chatModel option[value="winzig"]')).toHaveCount(1);
 
-  // … und ist auf dem Handy automatisch vorgewählt (Desktop: starkes Modell).
+  // … auf dem Handy ist das empfohlene 1.5B vorgewählt (Desktop: starkes 3B).
   const val = await page.locator('#chatModel').inputValue();
-  if (testInfo.project.name.includes('mobile')) expect(val).toBe('winzig');
+  if (testInfo.project.name.includes('mobile')) expect(val).toBe('klein');
   else expect(val).toBe('standard');
 });
 


### PR DESCRIPTION
## Was ist neu
Auf Wunsch „nur das beste kostenlose" Modell: Der lokale KI-Assistent nutzt jetzt durchgängig die **Qwen-2.5-Familie** — in kleiner Größe das beste mehrsprachige Modell mit guter **Deutsch-Fähigkeit**, und in WebLLM verfügbar. (Googles Gemini Nano wäre stärker, läuft aber nur über Android-System-APIs, nicht in einer Web-App.)

## Änderungen
- `js/aiengine.js`: `MODELS` = **Qwen 2.5 0.5B / 1.5B / 3B**. Handy-Standard auf das empfohlene **1.5B** (~1 GB) statt 0.5B; Desktop **3B**. Ältere Handys können in den Einstellungen auf **0.5B** wechseln.
- `index.html` / `README.md`: Texte auf Qwen 2.5 vereinheitlicht.
- `tests/chat-ui.spec.js`: Handy-Default-Erwartung auf `klein` (1.5B) angepasst.

## Tests
`npx playwright test` → **alle grün** (Engine gemockt, kein echter Download in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbmT5bBB85BGbCy9rVzdTk)_