### PR TITLE
Service-Worker-Cache auf v2026-33 (KI-Chat-Fixes ausliefern)

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-32';
+const CACHE = 'techdoku-v2026-33';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier


### PR DESCRIPTION
Erhöht die Service-Worker-Cache-Version auf `v2026-33`, damit die KI-Chat-Bugfixes aus #36 (Eingabefeld-Breite, Feld-Attribute, Deutsch-Prompt) bei bestehenden Installationen tatsächlich ausgeliefert werden. Ohne Versionsbump liefert der installierte Service Worker weiter die alten gecachten Dateien.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbmT5bBB85BGbCy9rVzdTk)_