### PR TITLE
Fix: KI startet auf Handys ohne shader-f16 nicht (f32-Fallback)

### DIFF
--- a/js/aiengine.js
+++ b/js/aiengine.js
@@ -61,6 +61,20 @@ export function currentModelId() {
   return MODELS[currentModelKey()].id;
 }
 
+// Prüft die tatsächliche WebGPU-Fähigkeit des Geräts. Wichtig fürs Handy:
+// Viele (v. a. Android-)GPUs können kein shader-f16 – dann laden wir statt der
+// q4f16-Variante automatisch die q4f32-Variante des gleichen Modells (etwas
+// mehr Speicher, läuft aber überall). Ohne diesen Tausch bricht die Engine auf
+// solchen Geräten beim Start ab.
+async function resolveModelId(modelId) {
+  const adapter = await navigator.gpu.requestAdapter();
+  if (!adapter) throw new Error('NO_WEBGPU'); // WebGPU vorhanden, aber deaktiviert/ohne Adapter
+  if (!adapter.features.has('shader-f16')) {
+    return modelId.replace('q4f16_1', 'q4f32_1');
+  }
+  return modelId;
+}
+
 // Lädt das Modell on demand. onProgress({ text, progress }) für die Anzeige.
 export async function ensureEngine(modelId, onProgress) {
   if (mock()) return mock();
@@ -69,14 +83,15 @@ export async function ensureEngine(modelId, onProgress) {
   if (loadingPromise) return loadingPromise;
 
   loadingPromise = (async () => {
+    const effectiveId = await resolveModelId(modelId);
     const webllm = await import(/* @vite-ignore */ WEBLLM_LIB);
-    const eng = await webllm.CreateMLCEngine(modelId, {
+    const eng = await webllm.CreateMLCEngine(effectiveId, {
       initProgressCallback: (r) => {
         if (onProgress) onProgress({ text: r.text || '', progress: r.progress || 0 });
       },
     });
     engine = eng;
-    loadedId = modelId;
+    loadedId = modelId; // unter der gewünschten ID merken (effectiveId ist Detail)
     return eng;
   })();
 

--- a/js/chat.js
+++ b/js/chat.js
@@ -129,9 +129,10 @@ async function runTurn(promptContent, displayUser) {
   } catch (e) {
     setStatus('');
     setBusy(false);
+    const detail = (e && e.message && e.message !== 'NO_WEBGPU') ? `\n\nTechnischer Hinweis: ${String(e.message).slice(0, 200)}` : '';
     const why = (e && e.message === 'NO_WEBGPU')
-      ? 'Dieses Gerät unterstützt das lokale KI-Modell nicht (WebGPU fehlt). Nutze ein aktuelles Chrome/Edge.'
-      : 'Das Modell konnte nicht antworten. Beim ersten Start braucht der Download etwas Geduld und WLAN.';
+      ? 'Dieses Gerät unterstützt das lokale KI-Modell nicht (WebGPU fehlt oder ist deaktiviert). Auf dem Handy: aktuelles Chrome (Android) bzw. Safari ab iOS 18.'
+      : 'Das Modell konnte nicht geladen werden oder nicht antworten. Beim ersten Start braucht der Download etwas Geduld und WLAN. Tipp: In den Einstellungen oben das sparsame Modell wählen und erneut versuchen.' + detail;
     history.push({ role: 'assistant', content: why });
     saveHistory();
     render();

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker – macht die App offline-fähig (Werkstatt ohne WLAN)
-const CACHE = 'techdoku-v2026-34';
+const CACHE = 'techdoku-v2026-35';
 
 // App-Shell – wird beim ersten Besuch gecacht.
 // Die OCR-Dateien (vendor/tesseract, vendor/tessdata) werden NICHT hier


### PR DESCRIPTION
## Problem
Auf vielen Handys (v. a. Android) startete der KI-Assistent nicht: Alle konfigurierten Modelle sind `q4f16_1`-Varianten und brauchen die WebGPU-Fähigkeit **`shader-f16`**, die viele Handy-GPUs nicht haben. Die Engine brach beim Laden ab — der Assistent wirkte kaputt.

## Fix
- `js/aiengine.js`: `resolveModelId()` prüft den WebGPU-Adapter. Ohne `shader-f16` wird automatisch die **`q4f32_1`-Variante** desselben Modells geladen (läuft überall, etwas mehr Speicher). `requestAdapter() === null` (WebGPU vorhanden, aber deaktiviert) wird jetzt sauber als „nicht unterstützt" behandelt.
- `js/chat.js`: Die Fehlermeldung nennt jetzt die **technische Ursache** (gekürzt) plus den Tipp, das sparsame Modell zu wählen — statt einer Pauschalmeldung.
- Modell-IDs (f16 **und** f32) gegen WebLLM 0.2.84 verifiziert; CDN-ESM-Bundle geprüft (`CreateMLCEngine` vorhanden).
- Service-Worker-Cache `v2026-35`.

## Tests
`npx playwright test` → **86 passed**. Der f16→f32-Pfad selbst braucht echtes WebGPU und ist daher nur am Gerät prüfbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbmT5bBB85BGbCy9rVzdTk)_